### PR TITLE
chore: release v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm build

--- a/packages/callscript/package.json
+++ b/packages/callscript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "callscript",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"type": "module",
 	"description": "a tool-calling script language for LLMs - the model authors ONE small script (plain JS, compiled to a validated, bounded, inert JSON plan - never executed) instead of calling tools one at a time. Adapter-based: mount AI SDK tools or plain { name, execute } literals",
 	"license": "Apache-2.0",


### PR DESCRIPTION
Release `v0.1.2` (`0.1.1` → `0.1.2`).

### Features

- add Apache License and update README and package.json to reflect new licensing (dd8f7d6)
- add release workflow and bump configuration for automated releases (316b88c)

### Refactors

- simplify engine.run call by removing unnecessary scope parameter (6968e8d)

### Chores

- add CI workflow for continuous integration and testing (c4d1b8b)
- release v0.1.1 (#1) (3378e50)
- release v0.1.1 (ff540fa)

### Other Changes

- Refactor session management to use a plain state value instead of a scope object (ad5d86d)