### PR TITLE
chore: release v0.1.3

### DIFF
--- a/packages/callscript/package.json
+++ b/packages/callscript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "callscript",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"type": "module",
 	"description": "a tool-calling script language for LLMs - the model authors ONE small script (plain JS, compiled to a validated, bounded, inert JSON plan - never executed) instead of calling tools one at a time. Adapter-based: mount AI SDK tools or plain { name, execute } literals",
 	"license": "Apache-2.0",


### PR DESCRIPTION
Release `v0.1.3` (`0.1.2` → `0.1.3`).

### Chores

- remove unnecessary registry-url parameter from setup-node action (bbd6303)