### PR TITLE
feat(js): desugar destructuring patterns into let steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const closed = await Promise.all(
 return { count: closed.length };
 ```
 
-This is **parsed, never executed**: each statement compiles into a step of the same inert plan - `const x = await tool(...)` is a call step, `const x = expr` a pure derivation, `if (cond) return v` a guard, `Promise.all(list.map(...))` a bounded fan-out (the visible `slice` is the bound), `try/catch` the error branch (`e` compiles to `$errors.<id>`), and the trailing `return` the output projection. What is stored, hashed, validated, approved, and resumed is always the JSON plan; the JS text is a frontend, not a runtime.
+This is **parsed, never executed**: each statement compiles into a step of the same inert plan - `const x = await tool(...)` is a call step, `const x = expr` a pure derivation, `const { items, total = 0 } = x` one derivation per bound name (`items = x.items`; array patterns, defaults, nesting, and rest all desugar the same way), `if (cond) return v` a guard, `Promise.all(list.map(...))` a bounded fan-out (the visible `slice` is the bound), `try/catch` the error branch (`e` compiles to `$errors.<id>`), and the trailing `return` the output projection. What is stored, hashed, validated, approved, and resumed is always the JSON plan; the JS text is a frontend, not a runtime.
 
 Semantics match the JS reading: **awaited calls run in statement order** (the compiler inserts `after` edges where no data already orders them), and `Promise.all` - the spelling the model already knows for concurrency - runs calls in parallel. A call's second argument carries per-step options: `github.closeIssue(args, { reason: "why", suspend: true, onError: "skip" })`. An un-awaited call to a mounted tool detaches (fire-and-forget) and a later script joins it with `const r = await job`.
 

--- a/packages/callscript/src/expr/parse.ts
+++ b/packages/callscript/src/expr/parse.ts
@@ -238,15 +238,17 @@ export function patternNames(pattern: acorn.Pattern): string[] {
 		case "Identifier":
 			return [pattern.name];
 		case "ArrayPattern":
-			return pattern.elements.flatMap((el) =>
-				el && el.type === "Identifier" ? [el.name] : [],
-			);
+			return pattern.elements.flatMap((el) => (el ? patternNames(el) : []));
 		case "ObjectPattern":
 			return pattern.properties.flatMap((prop) =>
-				prop.type === "Property" && prop.value.type === "Identifier"
-					? [prop.value.name]
-					: [],
+				prop.type === "Property"
+					? patternNames(prop.value as acorn.Pattern)
+					: patternNames(prop.argument),
 			);
+		case "AssignmentPattern":
+			return patternNames(pattern.left);
+		case "RestElement":
+			return patternNames(pattern.argument);
 		default:
 			return [];
 	}

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -304,6 +304,187 @@ describe("statement forms", () => {
 	});
 });
 
+describe("destructuring", () => {
+	// the dominant model spelling for "read fields off a result": every
+	// pattern desugars into the let steps the author could have written,
+	// so the plan format, validation, and reconciliation see nothing new
+
+	it("an object pattern on a call result reads fields off the minted call step", () => {
+		const script = parseJsScript(`
+			const { items, total } = await github.listIssues({ repo: "api" });
+			return { n: items.length, total };
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.listIssues", args: { repo: "api" } },
+			{ id: "items", let: "s1.items" },
+			{ id: "total", let: "s1.total" },
+		]);
+		expect(script.output).toBe("{ n: items.length, total }");
+	});
+
+	it("renames, defaults, nesting, string keys, and object rest", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { items: list = [], meta: { page = 1 }, "x-total": total, ...rest } = res;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "list", let: "res.items === undefined ? ([]) : res.items" },
+			{ id: "page", let: "res.meta.page === undefined ? (1) : res.meta.page" },
+			{ id: "total", let: 'res["x-total"]' },
+			{
+				id: "rest",
+				let: 'Object.fromEntries(Object.entries(res).filter(e => e[0] !== "items" && e[0] !== "meta" && e[0] !== "x-total"))',
+			},
+		]);
+	});
+
+	it("array patterns: index reads, holes skip, rest slices", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			const [first, , third, ...others] = issues;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "first", let: "issues[0]" },
+			{ id: "third", let: "issues[2]" },
+			{ id: "others", let: "issues.slice(3)" },
+		]);
+	});
+
+	it("a nested pattern under a default reads from one minted id", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { meta: { page } = { page: 0 } } = res;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "s1", let: "res.meta === undefined ? ({ page: 0 }) : res.meta" },
+			{ id: "page", let: "s1.page" },
+		]);
+	});
+
+	it("a path source is read directly; anything else is derived once", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { total } = res.meta;
+			const { length } = res.items.filter(i => i.stale);
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "total", let: "res.meta.total" },
+			{ id: "s1", let: "res.items.filter(i => i.stale)" },
+			{ id: "length", let: "s1.length" },
+		]);
+	});
+
+	it("inside try, the fields exist only when the call succeeded", () => {
+		const script = parseJsScript(`
+			try {
+				const { closed } = await github.closeIssue({ number: 7 });
+				const msg = \`closed \${closed}\`;
+			} catch (e) {
+				await slack.post({ text: e.message });
+			}
+		`);
+		const [call, closed, msg, failed] = script.steps as [
+			CallStep,
+			LetStep,
+			LetStep,
+			CallStep,
+		];
+		expect(call).toEqual({
+			id: "s1",
+			call: "github.closeIssue",
+			args: { number: 7 },
+			onError: "skip",
+		});
+		expect(closed).toEqual({
+			id: "closed",
+			let: "s1.closed",
+			if: "!($errors.s1)",
+		});
+		expect(msg).toEqual({
+			id: "msg",
+			let: "`closed ${closed}`",
+			if: "!($errors.s1)",
+		});
+		expect(failed.if).toBe("$errors.s1");
+		expect(failed.args).toEqual({ text: "=$errors.s1.message" });
+	});
+
+	it("a nested pattern in a Promise.all tuple reads off its own call", () => {
+		const script = parseJsScript(`
+			const [{ closed }, posted] = await Promise.all([
+				github.closeIssue({ number: 7 }),
+				slack.post({ text: "hi" }),
+			]);
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.closeIssue", args: { number: 7 } },
+			{ id: "posted", call: "slack.post", args: { text: "hi" } },
+			{ id: "closed", let: "s1.closed" },
+		]);
+	});
+
+	it("minted ids never collide with names bound deep in a pattern", () => {
+		const script = parseJsScript(`
+			const { a: { s1 } } = await github.getThing({});
+		`);
+		expect(script.steps.map((s) => s.id)).toEqual(["s2", "s1"]);
+	});
+
+	it("runs end to end through the engine", async () => {
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => ({
+				items: [{ number: 1 }, { number: 2 }, { number: 3 }],
+				meta: { total: 3 },
+			}),
+		});
+		const engine = callscript({ tools: [listIssues] });
+		const result = await engine.run({
+			script: `
+				const { items, meta: { total, page = 1 }, missing = "none" } = await github.listIssues({});
+				const [head, ...tail] = items;
+				return { head, tail: tail.length, total, page, missing };
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") {
+			expect(result.output).toEqual({
+				head: { number: 1 },
+				tail: 2,
+				total: 3,
+				page: 1,
+				missing: "none",
+			});
+		}
+	});
+
+	it("computed keys, forbidden keys, and destructured detached calls stay rejected", () => {
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					const res = await github.listIssues({});
+					const { [key]: v } = res;
+				`),
+			)[0],
+		).toMatch(/computed key/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					const res = await github.listIssues({});
+					const { constructor } = res;
+				`),
+			)[0],
+		).toMatch(/constructor/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`const { id } = svc.export({});`, {
+					tools: ["svc.export"],
+				}),
+			)[0],
+		).toMatch(/detached call to one name/);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -234,6 +234,119 @@ export function parseJsScript(
 		return out;
 	};
 
+	/* ----------------------------- destructuring --------------------------- */
+
+	/** `src.key`, or `src["odd key"]` when the key is not an identifier. */
+	const memberSrc = (src: string, key: string): string =>
+		/^[A-Za-z_$][\w$]*$/.test(key)
+			? `${src}.${key}`
+			: `${src}[${JSON.stringify(key)}]`;
+
+	/** A pattern property's static key; undefined when computed. */
+	const propertyKey = (prop: acorn.AssignmentProperty): string | undefined => {
+		if (prop.computed) return undefined;
+		if (prop.key.type === "Identifier") return prop.key.name;
+		if (
+			prop.key.type === "Literal" &&
+			(typeof prop.key.value === "string" || typeof prop.key.value === "number")
+		) {
+			return String(prop.key.value);
+		}
+		return undefined;
+	};
+
+	/** A derivation the desugar generated: grammar-checked (a forbidden
+	 * key like `constructor` surfaces here, at the pattern's line). */
+	const pushLet = (
+		node: acorn.AnyNode,
+		id: string,
+		text: string,
+		ctx: Ctx,
+	): void => {
+		try {
+			parseExpr(text);
+		} catch (err) {
+			issue(node, err instanceof ExprError ? err.message : String(err));
+			return;
+		}
+		pushStep({ id, let: text }, ctx);
+	};
+
+	/**
+	 * DESTRUCTURING: `const { items, total = 0 } = x` and `const [head,
+	 * ...tail] = xs` desugar into one `let` step per bound name - a field
+	 * read off the source (`items = x.items`), which is exactly the
+	 * "bind to one name and read fields off it" spelling the plan already
+	 * has. `src` is always a cheap path off a step id, so a default may
+	 * repeat it (`x.total === undefined ? 0 : x.total`); a nested pattern
+	 * under a default reads from one minted id instead. Object rest keeps
+	 * every key the pattern did not name. Nothing here changes the plan
+	 * format: the steps are the ones the author could have written.
+	 */
+	const bindPattern = (pattern: acorn.Pattern, src: string, ctx: Ctx): void => {
+		switch (pattern.type) {
+			case "Identifier":
+				pushLet(pattern, pattern.name, src, ctx);
+				return;
+			case "AssignmentPattern": {
+				const fallback = exprSrc(pattern.right as acorn.AnyNode, ctx);
+				if (fallback === undefined) return;
+				const value = `${src} === undefined ? (${fallback}) : ${src}`;
+				if (pattern.left.type === "Identifier") {
+					pushLet(pattern, pattern.left.name, value, ctx);
+					return;
+				}
+				const id = mint();
+				pushLet(pattern, id, value, ctx);
+				bindPattern(pattern.left, id, ctx);
+				return;
+			}
+			case "ObjectPattern": {
+				const named: string[] = [];
+				for (const prop of pattern.properties) {
+					if (prop.type === "RestElement") {
+						const keep =
+							named.length === 0
+								? "true"
+								: named
+										.map((k) => `e[0] !== ${JSON.stringify(k)}`)
+										.join(" && ");
+						bindPattern(
+							prop.argument,
+							`Object.fromEntries(Object.entries(${src}).filter(e => ${keep}))`,
+							ctx,
+						);
+						continue;
+					}
+					const key = propertyKey(prop);
+					if (key === undefined) {
+						issue(
+							prop,
+							"destructure with plain keys - a computed key ([k]) is not a static binding",
+						);
+						continue;
+					}
+					named.push(key);
+					bindPattern(prop.value as acorn.Pattern, memberSrc(src, key), ctx);
+				}
+				return;
+			}
+			case "ArrayPattern": {
+				pattern.elements.forEach((el, index) => {
+					if (el === null) return; // a hole skips the element
+					if (el.type === "RestElement") {
+						bindPattern(el.argument, `${src}.slice(${index})`, ctx);
+						return;
+					}
+					bindPattern(el, `${src}[${index}]`, ctx);
+				});
+				return;
+			}
+			default:
+				issue(pattern, `unsupported binding pattern (${pattern.type})`);
+		}
+	};
+
 	/* ----------------------------- args & opts ----------------------------- */
 
 	/** A node that is pure JSON - embeddable as literal args. */
@@ -686,34 +799,25 @@ export function parseJsScript(
 						"one tool call per try - give each risky call its own try/catch",
 					);
 				}
-				const names: (string | undefined)[] =
-					binding === undefined
-						? inner.elements.map(() => undefined)
-						: binding.type === "ArrayPattern"
-							? binding.elements.map((el) =>
-									el === null
-										? undefined
-										: el.type === "Identifier"
-											? el.name
-											: undefined,
-								)
-							: [];
-				if (binding !== undefined && binding.type === "ArrayPattern") {
-					if (binding.elements.length !== inner.elements.length) {
-						return issue(
-							binding,
-							"destructure one name per call: const [a, b] = await Promise.all([...])",
-						);
-					}
-					if (
-						binding.elements.some(
-							(el) => el !== null && el.type !== "Identifier",
-						)
-					) {
-						return issue(binding, "plain names only in the destructuring");
-					}
+				// `const [a, b] = ...` names the calls; a nested pattern in an
+				// element (`[{ closed }, b]`) reads off its own minted call.
+				const elements =
+					binding?.type === "ArrayPattern" ? binding.elements : undefined;
+				if (
+					elements !== undefined &&
+					elements.length !== inner.elements.length
+				) {
+					return issue(
+						binding!,
+						"destructure one name per call: const [a, b] = await Promise.all([...])",
+					);
 				}
+				const names: (string | undefined)[] = inner.elements.map((_, i) => {
+					const el = elements?.[i];
+					return el && el.type === "Identifier" ? el.name : undefined;
+				});
 				const compiled: CallStep[] = [];
+				const byIndex: (CallStep | undefined)[] = [];
 				for (const [index, el] of inner.elements.entries()) {
 					if (!el || el.type === "SpreadElement") {
 						issue(inner, "Promise.all takes plain tool calls, no holes/spread");
@@ -729,6 +833,7 @@ export function parseJsScript(
 						continue;
 					}
 					const step = compileCall(callNode, names[index] ?? mint(), ctx);
+					byIndex[index] = step;
 					if (step !== undefined) compiled.push(step);
 				}
 				// All elements chain after the SAME prior frontier, then the
@@ -742,15 +847,33 @@ export function parseJsScript(
 					if (step.await !== false) nextFrontier.push(step.id);
 				}
 				frontier = nextFrontier.length > 0 ? nextFrontier : before;
-				// An Identifier binding gets the tuple as a value.
-				if (binding !== undefined && binding.type === "Identifier") {
-					pushStep(
-						{
-							id: binding.name,
-							let: `[${compiled.map((s) => s.id).join(", ")}]`,
-						},
-						ctx,
-					);
+				if (elements !== undefined) {
+					// Nested patterns in the tuple read off their own call step.
+					elements.forEach((el, index) => {
+						const step = byIndex[index];
+						if (el === null || el.type === "Identifier" || step === undefined) {
+							return;
+						}
+						if (el.type === "RestElement") {
+							issue(
+								el,
+								"destructure one name per call: const [a, b] = await Promise.all([...])",
+							);
+							return;
+						}
+						bindPattern(el, step.id, ctx);
+					});
+				} else if (binding !== undefined) {
+					// Any other binding gets the tuple as a value - a name
+					// directly, a pattern through a minted tuple step.
+					const tuple = `[${compiled.map((s) => s.id).join(", ")}]`;
+					if (binding.type === "Identifier") {
+						pushStep({ id: binding.name, let: tuple }, ctx);
+					} else {
+						const id = mint();
+						pushStep({ id, let: tuple }, ctx);
+						bindPattern(binding, id, ctx);
+					}
 				}
 				return undefined;
 			}
@@ -760,16 +883,23 @@ export function parseJsScript(
 			);
 		}
 
-		// Plain awaited tool call.
-		if (binding !== undefined && bindingName === undefined) {
-			return issue(
-				binding,
-				"destructuring a call result is not supported - bind it to one name and read fields off it",
-			);
-		}
+		// Plain awaited tool call. A destructured binding reads its fields
+		// off the call step: `const { items } = await t()` is the call under
+		// a minted id plus `items = <id>.items` - inside a try, only when
+		// the call succeeded (the catch branch owns the failure).
 		const step = compileCall(arg, bindingName ?? mint(), ctx);
 		if (step === undefined) return undefined;
-		return pushCall(step, ctx);
+		pushCall(step, ctx);
+		if (binding !== undefined && bindingName === undefined) {
+			bindPattern(
+				binding,
+				step.id,
+				where === "try"
+					? { ...ctx, cond: composeCond(ctx.cond, `!($errors.${step.id})`) }
+					: ctx,
+			);
+		}
+		return step;
 	};
 
 	/* ------------------------------ statements ----------------------------- */
@@ -784,17 +914,17 @@ export function parseJsScript(
 				compileAwaited(decl.init, decl.id, ctx, "statement");
 				continue;
 			}
-			if (decl.id.type !== "Identifier") {
-				issue(
-					decl.id,
-					"bind derived values to one name - destructure by deriving fields in later consts",
-				);
-				continue;
-			}
 			// Un-awaited call to a MOUNTED tool -> detached (fire-and-forget).
 			if (decl.init.type === "CallExpression") {
 				const name = dottedName(decl.init.callee);
 				if (name !== undefined && isMountedTool(name)) {
+					if (decl.id.type !== "Identifier") {
+						issue(
+							decl.id,
+							"bind a detached call to one name - const job = tool.name({ ... }); a later script joins it with await job",
+						);
+						continue;
+					}
 					const step = compileCall(decl.init, decl.id.name, ctx);
 					if (step !== undefined) {
 						step.await = false;
@@ -805,6 +935,17 @@ export function parseJsScript(
 			}
 			const text = exprSrc(decl.init, ctx);
 			if (text === undefined) continue;
+			if (decl.id.type !== "Identifier") {
+				// Destructuring a pure value: read the fields straight off a
+				// name/path source; anything else is derived once first.
+				let src = text;
+				if (dottedName(decl.init) === undefined) {
+					src = mint();
+					pushStep({ id: src, let: text }, ctx);
+				}
+				bindPattern(decl.id, src, ctx);
+				continue;
+			}
 			pushStep({ id: decl.id.name, let: text }, ctx);
 		}
 	};


### PR DESCRIPTION
`const { items, total = 0 } = await tool(...)`, `const [head, ...tail] = xs`, renames, nesting, string keys, object rest, and nested patterns inside a Promise.all tuple now compile into the let steps the author could have written (`items = s1.items`) instead of being rejected. Inside try/catch the derived fields are guarded on the call's success. Computed keys, forbidden keys, and destructured detached calls keep a pointed message.

`patternNames` recurses into nested, default, and rest patterns so minted ids never collide with names bound deep in a pattern.