### PR TITLE
feat(js): compile the spellings models reach for most

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const closed = await Promise.all(
 return { count: closed.length };
 ```
 
-This is **parsed, never executed**: each statement compiles into a step of the same inert plan - `const x = await tool(...)` is a call step, `const x = expr` a pure derivation, `if (cond) return v` a guard, `Promise.all(list.map(...))` a bounded fan-out (the visible `slice` is the bound), `try/catch` the error branch (`e` compiles to `$errors.<id>`), and the trailing `return` the output projection. What is stored, hashed, validated, approved, and resumed is always the JSON plan; the JS text is a frontend, not a runtime.
+This is **parsed, never executed**: each statement compiles into a step of the same inert plan - `const x = await tool(...)` is a call step, `const x = expr` a pure derivation, `const { items, total = 0 } = x` one derivation per bound name (`items = x.items`; array patterns, defaults, nesting, and rest all desugar the same way), `if (cond) return v` a guard, `Promise.all(list.map(...))` a bounded fan-out (the visible `slice` is the bound), `try/catch` the error branch (`e` compiles to `$errors.<id>`), and the trailing `return` the output projection. What is stored, hashed, validated, approved, and resumed is always the JSON plan; the JS text is a frontend, not a runtime.
 
 Semantics match the JS reading: **awaited calls run in statement order** (the compiler inserts `after` edges where no data already orders them), and `Promise.all` - the spelling the model already knows for concurrency - runs calls in parallel. A call's second argument carries per-step options: `github.closeIssue(args, { reason: "why", suspend: true, onError: "skip" })`. An un-awaited call to a mounted tool detaches (fire-and-forget) and a later script joins it with `const r = await job`.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ return { count: closed.length };
 
 This is **parsed, never executed**: each statement compiles into a step of the same inert plan - `const x = await tool(...)` is a call step, `const x = expr` a pure derivation, `const { items, total = 0 } = x` one derivation per bound name (`items = x.items`; array patterns, defaults, nesting, and rest all desugar the same way), `if (cond) return v` a guard, `Promise.all(list.map(...))` a bounded fan-out (the visible `slice` is the bound), `try/catch` the error branch (`e` compiles to `$errors.<id>`), and the trailing `return` the output projection. What is stored, hashed, validated, approved, and resumed is always the JSON plan; the JS text is a frontend, not a runtime.
 
+The frontend also desugars the spellings models reach for most, so they compile instead of costing a retry - every one of them into steps the author could have written by hand, never a new plan construct:
+
+- **Destructuring**: `const { items, total = 0 } = await repo.list({})` is the call plus one derivation per name (`items = s1.items`); `const [head, ...tail] = items` reads by index and `slice`. Renames, defaults, nesting, string keys, and object rest all work; inside `try/catch` the fields exist only when the call succeeded.
+- **Nested awaits**: `return { issues: await repo.list({}) }` or `close({ id: (await find({})).id })` hoists each awaited call into its own step, in source order, and the expression reads the step id. An await inside an arrow or a fan-out's own arguments stays rejected with the fix.
+- **Loop bodies**: `for (const i of list) { const n = i.number; if (!i.stale) continue; await close({ n }) }` is one fan-out - the guards become a `.filter` on the list and the locals inline into the call. Two calls, an `else`, or a `return` is a real loop and is rejected with the `Promise.all(list.map(...))` spelling.
+- **Conditional values**: `let label = "none"; if (issues.length) label = "some"` is the single derivation `label = cond ? "some" : "none"`.
+- **`in`**: `"labels" in issue` checks the object's own keys - plain data only, never a prototype chain.
+
 Semantics match the JS reading: **awaited calls run in statement order** (the compiler inserts `after` edges where no data already orders them), and `Promise.all` - the spelling the model already knows for concurrency - runs calls in parallel. A call's second argument carries per-step options: `github.closeIssue(args, { reason: "why", suspend: true, onError: "skip" })`. An un-awaited call to a mounted tool detaches (fire-and-forget) and a later script joins it with `const r = await job`.
 
 Everything outside the recognized grammar is rejected before anything runs, with the message that names the callscript spelling - `while` points at the bounded fan-out, reassignment at single-assignment consts, `new Set` at the dedupe idiom - so one retry converges:

--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ The frontend also desugars the spellings models reach for most, so they compile 
 - **Destructuring**: `const { items, total = 0 } = await repo.list({})` is the call plus one derivation per name (`items = s1.items`); `const [head, ...tail] = items` reads by index and `slice`. Renames, defaults, nesting, string keys, and object rest all work; inside `try/catch` the fields exist only when the call succeeded.
 - **Nested awaits**: `return { issues: await repo.list({}) }` or `close({ id: (await find({})).id })` hoists each awaited call into its own step, in source order, and the expression reads the step id. An await inside an arrow or a fan-out's own arguments stays rejected with the fix.
 - **Loop bodies**: `for (const i of list) { const n = i.number; if (!i.stale) continue; await close({ n }) }` is one fan-out - the guards become a `.filter` on the list and the locals inline into the call. Two calls, an `else`, or a `return` is a real loop and is rejected with the `Promise.all(list.map(...))` spelling.
+- **Fan-out arrows with a block**: `list.map(async i => { const n = i.number; if (!i.stale) return; return await close({ n }) })` follows the same grammar as a loop body - `return;` is the arrow's `continue`.
 - **Conditional values**: `let label = "none"; if (issues.length) label = "some"` is the single derivation `label = cond ? "some" : "none"`.
+- **Wrappers**: `(async () => { ... })()` and `async function main() { ... } main()` compile as the program - the body's `return` is the output.
 - **`in`**: `"labels" in issue` checks the object's own keys - plain data only, never a prototype chain.
+
+Expressions cover the pure natives models reach for: `at`, `findLast`, `toSorted`, `toReversed`, `substring`, `trimStart`, `parseInt`, `parseFloat`, `encodeURIComponent`, `Object.assign` (non-mutating), spread in call arguments (`Math.max(...xs)`), and the converters as callbacks (`xs.map(Number)`, `xs.filter(Boolean)`). Array mutators name the immutable spelling; `Math.random` is out because a run must replay deterministically.
 
 Semantics match the JS reading: **awaited calls run in statement order** (the compiler inserts `after` edges where no data already orders them), and `Promise.all` - the spelling the model already knows for concurrency - runs calls in parallel. A call's second argument carries per-step options: `github.closeIssue(args, { reason: "why", suspend: true, onError: "skip" })`. An un-awaited call to a mounted tool detaches (fire-and-forget) and a later script joins it with `const r = await job`.
 

--- a/packages/callscript/src/expr.test.ts
+++ b/packages/callscript/src/expr.test.ts
@@ -113,6 +113,67 @@ describe("evalExpr", () => {
 		).toThrow(/budget/);
 	});
 
+	it("covers the pure array and string methods models reach for", () => {
+		const xs = [3, 1, 2];
+		expect(evalExpr("xs.at(-1)", { xs })).toBe(2);
+		expect(evalExpr("xs.findLast(x => x > 1)", { xs })).toBe(2);
+		expect(evalExpr("xs.findLastIndex(x => x > 1)", { xs })).toBe(2);
+		expect(evalExpr("xs.lastIndexOf(1)", { xs })).toBe(1);
+		expect(evalExpr("xs.toSorted((a, b) => a - b)", { xs })).toEqual([1, 2, 3]);
+		expect(evalExpr("xs.toReversed()", { xs })).toEqual([2, 1, 3]);
+		expect(xs).toEqual([3, 1, 2]); // untouched
+		const s = "  Hi there ";
+		expect(evalExpr("s.trimStart()", { s })).toBe("Hi there ");
+		expect(evalExpr("s.trimEnd()", { s })).toBe("  Hi there");
+		expect(evalExpr("s.trim().at(0)", { s })).toBe("H");
+		expect(evalExpr("s.trim().substring(0, 2)", { s })).toBe("Hi");
+		expect(evalExpr("s.trim().charCodeAt(0)", { s })).toBe(72);
+		expect(evalExpr('s.trim().concat("!", 1)', { s })).toBe("Hi there!1");
+	});
+
+	it("callable globals: bare calls, and as callbacks", () => {
+		expect(evalExpr('parseInt("42px")', {})).toBe(42);
+		expect(evalExpr('parseFloat("4.5kg")', {})).toBe(4.5);
+		expect(evalExpr('isNaN("x") && isFinite(1)', {})).toBe(true);
+		expect(evalExpr('encodeURIComponent("a b&c")', {})).toBe("a%20b%26c");
+		expect(evalExpr('decodeURIComponent("a%20b")', {})).toBe("a b");
+		expect(evalExpr('["1", "2"].map(Number)', {})).toEqual([1, 2]);
+		expect(evalExpr("[1, 2].map(String)", {})).toEqual(["1", "2"]);
+		expect(evalExpr('[0, 1, "", "a"].filter(Boolean)', {})).toEqual([1, "a"]);
+		// still a namespace
+		expect(
+			evalExpr("Number.isInteger(2) && Number.MAX_SAFE_INTEGER > 0", {}),
+		).toBe(true);
+		// a bare global is a value the checker knows, not a free reference
+		expect(
+			collectRefs(parseExpr("xs.map(parseInt).filter(isFinite)")).size,
+		).toBe(1);
+	});
+
+	it("spreads arrays into call arguments and merges with Object.assign", () => {
+		expect(evalExpr("Math.max(...xs, 0)", { xs: [3, 1, 2] })).toBe(3);
+		expect(evalExpr("Math.min(...xs)", { xs: [3, 1, 2] })).toBe(1);
+		expect(() => evalExpr("Math.max(...5)", {})).toThrow(
+			/Spread expects an array/,
+		);
+		const o = { a: 1 };
+		expect(evalExpr("Object.assign({}, o, { b: 2 }, null)", { o })).toEqual({
+			a: 1,
+			b: 2,
+		});
+		expect(o).toEqual({ a: 1 }); // the merge never lands in a script value
+	});
+
+	it("names the immutable spelling for mutators and refuses Math.random", () => {
+		expect(() => evalExpr("xs.push(1)", { xs: [] })).toThrow(
+			/mutates.*\[\.\.\.xs, x\]/,
+		);
+		expect(() => evalExpr("xs.splice(0, 1)", { xs: [1] })).toThrow(/mutates/);
+		expect(() => evalExpr("Math.random()", {})).toThrow(
+			/replay deterministically/,
+		);
+	});
+
 	it("does not allow calling functions read from data", () => {
 		const evil = { fn: () => "boom" };
 		expect(() => evalExpr("evil.fn()", { evil })).toThrow(ExprError);

--- a/packages/callscript/src/expr.test.ts
+++ b/packages/callscript/src/expr.test.ts
@@ -169,6 +169,20 @@ describe("evalExpr", () => {
 		);
 	});
 
+	it("names the alternative for what `new` was reaching for", () => {
+		expect(() => evalExpr("new Date(x) < Date.now()", { x: "2020" })).toThrow(
+			/new Date.*Date\.parse\(s\).*Date\.now\(\)/,
+		);
+		expect(() => evalExpr('new RegExp("a").test(s)', { s: "a" })).toThrow(
+			/new RegExp.*includes/,
+		);
+		expect(() => evalExpr("new Map()", {})).toThrow(/new Map.*groupBy/);
+		expect(() => evalExpr('new Error("x")', {})).toThrow(
+			/new Error.*if \(cond\) return/,
+		);
+		expect(() => evalExpr("new Foo()", {})).toThrow(/new Foo.*literals/);
+	});
+
 	it("encodes and decodes base64 (incl. url-safe)", () => {
 		expect(evalExpr('Base64.encode("hi")', {})).toBe("aGk=");
 		expect(evalExpr('Base64.decode("aGk=")', {})).toBe("hi");

--- a/packages/callscript/src/expr.test.ts
+++ b/packages/callscript/src/expr.test.ts
@@ -143,6 +143,26 @@ describe("evalExpr", () => {
 		]);
 	});
 
+	it("supports `in` over own keys of data", () => {
+		expect(evalExpr('"tier" in user', env)).toBe(true);
+		expect(evalExpr('"email" in user', env)).toBe(false);
+		expect(evalExpr("0 in issues && 3 in issues === false", env)).toBe(true);
+		// data only - no prototype chain leaks through
+		expect(evalExpr('"map" in issues', env)).toBe(false);
+		expect(evalExpr('"toString" in user', env)).toBe(false);
+		// the check stays inside the guard
+		expect(
+			evalExpr('issues.filter(i => "labels" in i && i.labels.length > 1)', env),
+		).toHaveLength(1);
+	});
+
+	it("`in` rejects non-objects and forbidden names", () => {
+		expect(() => evalExpr('"a" in 42', {})).toThrow(/non-object/);
+		expect(() => evalExpr('"a" in null', {})).toThrow(/non-object/);
+		expect(() => evalExpr('"constructor" in user', env)).toThrow(/not allowed/);
+		expect(() => evalExpr('"__proto__" in user', env)).toThrow(/not allowed/);
+	});
+
 	it("bans `new` with a hint at the alternatives", () => {
 		expect(() => evalExpr("[...new Set(xs)]", { xs: [1] })).toThrow(
 			/Object\.groupBy|indexOf/,

--- a/packages/callscript/src/expr/eval.ts
+++ b/packages/callscript/src/expr/eval.ts
@@ -52,6 +52,9 @@ const SAFE_OBJECT = Object.freeze({
 			throw new ExprError("Object.fromEntries expects an array", "type");
 		return Object.fromEntries(e as [string, unknown][]);
 	},
+	/** Non-mutating: the merge lands in a fresh object, never in `target`. */
+	assign: (...objs: unknown[]) =>
+		Object.assign({}, ...objs.map((o) => (o == null ? {} : asRecord(o)))),
 	/** Standard since ES2024 and THE group-by primitive scripts need. */
 	groupBy: (items: unknown, fn: unknown) => {
 		if (!Array.isArray(items))
@@ -94,15 +97,44 @@ const SAFE_BASE64 = Object.freeze({
 		Buffer.from(String(v), "base64url").toString("utf8"),
 });
 
-const SAFE_NUMBER = Object.freeze({
-	isFinite: Number.isFinite,
-	isInteger: Number.isInteger,
-	isNaN: Number.isNaN,
-	parseFloat: Number.parseFloat,
-	parseInt: Number.parseInt,
-	MAX_SAFE_INTEGER: Number.MAX_SAFE_INTEGER,
-	MIN_SAFE_INTEGER: Number.MIN_SAFE_INTEGER,
-});
+/** `Number` is both a namespace (Number.isInteger) and a converter
+ * (Number("3")) - and, as a bare value, the callback in `xs.map(Number)`. */
+const SAFE_NUMBER = Object.freeze(
+	Object.assign((v: unknown) => Number(v), {
+		isFinite: Number.isFinite,
+		isInteger: Number.isInteger,
+		isNaN: Number.isNaN,
+		parseFloat: Number.parseFloat,
+		parseInt: Number.parseInt,
+		MAX_SAFE_INTEGER: Number.MAX_SAFE_INTEGER,
+		MIN_SAFE_INTEGER: Number.MIN_SAFE_INTEGER,
+	}),
+);
+
+/**
+ * Globals callable as bare functions - `String(4)`, `parseInt(s)`,
+ * `encodeURIComponent(q)` - and passable as callbacks: `xs.map(String)`,
+ * `xs.filter(Boolean)`. Pure value-to-value natives, no host authority.
+ */
+const CALLABLE_GLOBALS: Record<string, (...args: unknown[]) => unknown> = {
+	Number: SAFE_NUMBER,
+	String: Object.freeze((v: unknown) => String(v)),
+	Boolean: Object.freeze((v: unknown) => Boolean(v)),
+	parseInt: Object.freeze((v: unknown, radix?: unknown) =>
+		Number.parseInt(String(v), radix as number | undefined),
+	),
+	parseFloat: Object.freeze((v: unknown) => Number.parseFloat(String(v))),
+	isNaN: Object.freeze((v: unknown) => Number.isNaN(Number(v))),
+	isFinite: Object.freeze((v: unknown) => Number.isFinite(Number(v))),
+	encodeURIComponent: Object.freeze((v: unknown) =>
+		encodeURIComponent(String(v)),
+	),
+	decodeURIComponent: Object.freeze((v: unknown) =>
+		decodeURIComponent(String(v)),
+	),
+	encodeURI: Object.freeze((v: unknown) => encodeURI(String(v))),
+	decodeURI: Object.freeze((v: unknown) => decodeURI(String(v))),
+};
 
 const NAMESPACES: Record<string, unknown> = {
 	Math: SAFE_MATH,
@@ -110,9 +142,9 @@ const NAMESPACES: Record<string, unknown> = {
 	Date: SAFE_DATE,
 	Object: SAFE_OBJECT,
 	Array: SAFE_ARRAY,
-	Number: SAFE_NUMBER,
 	Base64: SAFE_BASE64,
 	undefined,
+	...CALLABLE_GLOBALS,
 };
 
 const NAMESPACE_VALUES = new Set<unknown>([
@@ -121,15 +153,20 @@ const NAMESPACE_VALUES = new Set<unknown>([
 	SAFE_DATE,
 	SAFE_OBJECT,
 	SAFE_ARRAY,
-	SAFE_NUMBER,
 	SAFE_BASE64,
+	...Object.values(CALLABLE_GLOBALS),
 ]);
 
-/** Globals callable as bare functions: Number("3"), String(4), Boolean(x). */
-const CALLABLE_GLOBALS: Record<string, (...args: unknown[]) => unknown> = {
-	Number: (v: unknown) => Number(v),
-	String: (v: unknown) => String(v),
-	Boolean: (v: unknown) => Boolean(v),
+/** Array mutators, named with the immutable spelling: script data never
+ * changes in place, and a copy is what the author wanted anyway. */
+const ARRAY_MUTATORS: Record<string, string> = {
+	push: "[...xs, x]",
+	unshift: "[x, ...xs]",
+	pop: "xs.slice(0, -1)",
+	shift: "xs.slice(1)",
+	splice: "xs.filter((_, i) => ...) or [...xs.slice(0, i), ...xs.slice(j)]",
+	fill: "xs.map(() => v)",
+	copyWithin: "a new array literal",
 };
 
 /* --------------------------- method whitelists ---------------------------- */
@@ -174,10 +211,17 @@ const ARRAY_METHODS: Record<
 	concat: (a, args) => a.concat(...(args as unknown[][])),
 	join: (a, [sep]) => a.join(sep as string | undefined),
 	flat: (a, [d]) => a.flat((d as number) ?? 1),
+	at: (a, [i]) => a.at(i as number),
+	findLast: (a, [f]) => a.findLast((x, i, arr) => asFn(f)(x, i, arr)),
+	findLastIndex: (a, [f]) => a.findLastIndex((x, i, arr) => asFn(f)(x, i, arr)),
+	lastIndexOf: (a, [v]) => a.lastIndexOf(v),
 	// Non-mutating variants: script data is immutable.
 	sort: (a, [f]) =>
 		[...a].sort(f === undefined ? undefined : (x, y) => Number(asFn(f)(x, y))),
+	toSorted: (a, [f]) =>
+		[...a].sort(f === undefined ? undefined : (x, y) => Number(asFn(f)(x, y))),
 	reverse: (a) => [...a].reverse(),
+	toReversed: (a) => [...a].reverse(),
 };
 
 const STRING_METHODS: Record<string, (s: string, args: unknown[]) => unknown> =
@@ -204,6 +248,12 @@ const STRING_METHODS: Record<string, (s: string, args: unknown[]) => unknown> =
 			return s.repeat(count);
 		},
 		localeCompare: (s, [v]) => s.localeCompare(String(v)),
+		at: (s, [i]) => s.at(i as number),
+		substring: (s, [a, b]) => s.substring(a as number, b as number | undefined),
+		trimStart: (s) => s.trimStart(),
+		trimEnd: (s) => s.trimEnd(),
+		charCodeAt: (s, [i]) => s.charCodeAt(i as number),
+		concat: (s, args) => s.concat(...args.map(String)),
 	};
 
 const NUMBER_METHODS: Record<string, (n: number, args: unknown[]) => unknown> =
@@ -295,17 +345,27 @@ function callMethod(obj: unknown, method: string, args: unknown[]): unknown {
 	if (NAMESPACE_VALUES.has(obj)) {
 		const fn = (obj as Record<string, unknown>)[method];
 		if (typeof fn !== "function") {
+			if (obj === SAFE_MATH && method === "random") {
+				throw new ExprError(
+					"Math.random is not available - a run must replay deterministically; take randomness from a tool or from input",
+					"forbidden",
+				);
+			}
 			throw new ExprError(`Unknown function "${method}"`, "reference");
 		}
 		return (fn as (...a: unknown[]) => unknown)(...args);
 	}
 	if (Array.isArray(obj)) {
 		const impl = ARRAY_METHODS[method];
-		if (!impl)
+		if (!impl) {
+			const instead = ARRAY_MUTATORS[method];
 			throw new ExprError(
-				`Array method "${method}" is not allowed`,
+				instead === undefined
+					? `Array method "${method}" is not allowed`
+					: `Array method "${method}" mutates - script data is immutable; build a new array: ${instead}`,
 				"forbidden",
 			);
+		}
 		return impl(obj, args);
 	}
 	if (typeof obj === "string") {
@@ -503,15 +563,25 @@ function evaluateCall(
 	ctx: EvalCtx,
 ): unknown {
 	const callee = node.callee;
-	const args = node.arguments.map((a) =>
-		evaluate(a as acorn.Expression, scope, ctx),
-	);
+	const args: unknown[] = [];
+	for (const a of node.arguments) {
+		if (a.type === "SpreadElement") {
+			// Math.max(...xs) - the spelling models reach for first
+			const v = evaluate(a.argument, scope, ctx);
+			if (!Array.isArray(v)) {
+				throw new ExprError("Spread expects an array", "type");
+			}
+			args.push(...v);
+		} else {
+			args.push(evaluate(a, scope, ctx));
+		}
+	}
 
 	if (callee.type === "Identifier") {
 		const fn = CALLABLE_GLOBALS[callee.name];
 		if (!fn) {
 			throw new ExprError(
-				`"${callee.name}" is not callable (only Number, String, Boolean)`,
+				`"${callee.name}" is not callable (only ${Object.keys(CALLABLE_GLOBALS).join(", ")})`,
 				"reference",
 			);
 		}

--- a/packages/callscript/src/expr/eval.ts
+++ b/packages/callscript/src/expr/eval.ts
@@ -607,6 +607,22 @@ function binary(op: string, l: unknown, r: unknown): unknown {
 			return l === r;
 		case "!==":
 			return l !== r;
+		case "in": {
+			// Own keys of DATA only: scripts see plain values, never a
+			// prototype chain, so `"map" in []` is false here (and the
+			// forbidden names stay unreachable through this door too).
+			if (r === null || typeof r !== "object") {
+				throw new ExprError(
+					`Cannot use "in" on a non-object (${r === null ? "null" : typeof r})`,
+					"type",
+				);
+			}
+			const key = String(l);
+			if (FORBIDDEN_PROPS.has(key)) {
+				throw new ExprError(`Access to "${key}" is not allowed`, "forbidden");
+			}
+			return Object.hasOwn(r, key);
+		}
 		default:
 			throw new ExprError(`Unsupported operator ${op}`, "syntax");
 	}

--- a/packages/callscript/src/expr/parse.ts
+++ b/packages/callscript/src/expr/parse.ts
@@ -36,6 +36,14 @@ export const GLOBAL_NAMES = new Set([
 	"Boolean",
 	"Base64",
 	"undefined",
+	"parseInt",
+	"parseFloat",
+	"isNaN",
+	"isFinite",
+	"encodeURIComponent",
+	"decodeURIComponent",
+	"encodeURI",
+	"decodeURI",
 ]);
 
 const ALLOWED_BINARY = new Set([
@@ -161,8 +169,8 @@ export function validateNode(node: acorn.AnyNode): void {
 				fail(callee, "computed callee");
 			}
 			for (const arg of node.arguments) {
-				if (arg.type === "SpreadElement") fail(arg, "spread in call arguments");
-				validateNode(arg);
+				// `Math.max(...xs)` spreads a script array - pure, so allowed.
+				validateNode(arg.type === "SpreadElement" ? arg.argument : arg);
 			}
 			return;
 		}

--- a/packages/callscript/src/expr/parse.ts
+++ b/packages/callscript/src/expr/parse.ts
@@ -195,14 +195,46 @@ export function validateNode(node: acorn.AnyNode): void {
 			if (!ALLOWED_UNARY.has(node.operator)) fail(node, node.operator);
 			validateNode(node.argument);
 			return;
-		case "NewExpression":
-			// `new Set(...)` is THE dedupe idiom - ban it with the alternative,
+		case "NewExpression": {
+			// Ban `new` with the alternative for what the author reached for,
 			// not just the rule, so the retry converges in one round trip.
-			throw new ExprError(
-				"Unsupported syntax: new. Dedupe with xs.filter((x, i, a) => a.indexOf(x) === i); " +
-					"group with Object.groupBy(xs, x => x.key).",
-				"syntax",
-			);
+			const what =
+				node.callee.type === "Identifier" ? node.callee.name : undefined;
+			switch (what) {
+				case "Date":
+					throw new ExprError(
+						"Unsupported syntax: new Date. Compare timestamps instead: " +
+							"Date.parse(s) for a date string, Date.now() for the current time.",
+						"syntax",
+					);
+				case "RegExp":
+					throw new ExprError(
+						"Unsupported syntax: new RegExp. Match with s.includes(...), " +
+							"s.startsWith(...), s.endsWith(...), or s.toLowerCase() === ...",
+						"syntax",
+					);
+				case "Set":
+				case "Map":
+					// `new Set(...)` is THE dedupe idiom.
+					throw new ExprError(
+						`Unsupported syntax: new ${what}. Dedupe with xs.filter((x, i, a) => a.indexOf(x) === i); ` +
+							"group with Object.groupBy(xs, x => x.key).",
+						"syntax",
+					);
+				case "Error":
+					throw new ExprError(
+						"Unsupported syntax: new Error. A failed call already fails the run; " +
+							"to end it yourself, guard: if (cond) return { ... }",
+						"syntax",
+					);
+				default:
+					throw new ExprError(
+						`Unsupported syntax: new${what ? ` ${what}` : ""}. Build plain objects and arrays with literals; ` +
+							"dedupe with xs.filter((x, i, a) => a.indexOf(x) === i).",
+						"syntax",
+					);
+			}
+		}
 		default:
 			fail(node);
 	}

--- a/packages/callscript/src/expr/parse.ts
+++ b/packages/callscript/src/expr/parse.ts
@@ -238,15 +238,17 @@ export function patternNames(pattern: acorn.Pattern): string[] {
 		case "Identifier":
 			return [pattern.name];
 		case "ArrayPattern":
-			return pattern.elements.flatMap((el) =>
-				el && el.type === "Identifier" ? [el.name] : [],
-			);
+			return pattern.elements.flatMap((el) => (el ? patternNames(el) : []));
 		case "ObjectPattern":
 			return pattern.properties.flatMap((prop) =>
-				prop.type === "Property" && prop.value.type === "Identifier"
-					? [prop.value.name]
-					: [],
+				prop.type === "Property"
+					? patternNames(prop.value as acorn.Pattern)
+					: patternNames(prop.argument),
 			);
+		case "AssignmentPattern":
+			return patternNames(pattern.left);
+		case "RestElement":
+			return patternNames(pattern.argument);
 		default:
 			return [];
 	}

--- a/packages/callscript/src/expr/parse.ts
+++ b/packages/callscript/src/expr/parse.ts
@@ -53,6 +53,7 @@ const ALLOWED_BINARY = new Set([
 	"!=",
 	"===",
 	"!==",
+	"in",
 ]);
 
 const ALLOWED_LOGICAL = new Set(["&&", "||", "??"]);

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -304,6 +304,187 @@ describe("statement forms", () => {
 	});
 });
 
+describe("destructuring", () => {
+	// the dominant model spelling for "read fields off a result": every
+	// pattern desugars into the let steps the author could have written,
+	// so the plan format, validation, and reconciliation see nothing new
+
+	it("an object pattern on a call result reads fields off the minted call step", () => {
+		const script = parseJsScript(`
+			const { items, total } = await github.listIssues({ repo: "api" });
+			return { n: items.length, total };
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.listIssues", args: { repo: "api" } },
+			{ id: "items", let: "s1.items" },
+			{ id: "total", let: "s1.total" },
+		]);
+		expect(script.output).toBe("{ n: items.length, total }");
+	});
+
+	it("renames, defaults, nesting, string keys, and object rest", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { items: list = [], meta: { page = 1 }, "x-total": total, ...rest } = res;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "list", let: "res.items === undefined ? ([]) : res.items" },
+			{ id: "page", let: "res.meta.page === undefined ? (1) : res.meta.page" },
+			{ id: "total", let: 'res["x-total"]' },
+			{
+				id: "rest",
+				let: 'Object.fromEntries(Object.entries(res).filter(e => e[0] !== "items" && e[0] !== "meta" && e[0] !== "x-total"))',
+			},
+		]);
+	});
+
+	it("array patterns: index reads, holes skip, rest slices", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			const [first, , third, ...others] = issues;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "first", let: "issues[0]" },
+			{ id: "third", let: "issues[2]" },
+			{ id: "others", let: "issues.slice(3)" },
+		]);
+	});
+
+	it("a nested pattern under a default reads from one minted id", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { meta: { page } = { page: 0 } } = res;
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "s1", let: "res.meta === undefined ? ({ page: 0 }) : res.meta" },
+			{ id: "page", let: "s1.page" },
+		]);
+	});
+
+	it("a path source is read directly; anything else is derived once", () => {
+		const script = parseJsScript(`
+			const res = await github.listIssues({ repo: "api" });
+			const { total } = res.meta;
+			const { length } = res.items.filter(i => i.stale);
+		`);
+		expect(script.steps.slice(1)).toEqual([
+			{ id: "total", let: "res.meta.total" },
+			{ id: "s1", let: "res.items.filter(i => i.stale)" },
+			{ id: "length", let: "s1.length" },
+		]);
+	});
+
+	it("inside try, the fields exist only when the call succeeded", () => {
+		const script = parseJsScript(`
+			try {
+				const { closed } = await github.closeIssue({ number: 7 });
+				const msg = \`closed \${closed}\`;
+			} catch (e) {
+				await slack.post({ text: e.message });
+			}
+		`);
+		const [call, closed, msg, failed] = script.steps as [
+			CallStep,
+			LetStep,
+			LetStep,
+			CallStep,
+		];
+		expect(call).toEqual({
+			id: "s1",
+			call: "github.closeIssue",
+			args: { number: 7 },
+			onError: "skip",
+		});
+		expect(closed).toEqual({
+			id: "closed",
+			let: "s1.closed",
+			if: "!($errors.s1)",
+		});
+		expect(msg).toEqual({
+			id: "msg",
+			let: "`closed ${closed}`",
+			if: "!($errors.s1)",
+		});
+		expect(failed.if).toBe("$errors.s1");
+		expect(failed.args).toEqual({ text: "=$errors.s1.message" });
+	});
+
+	it("a nested pattern in a Promise.all tuple reads off its own call", () => {
+		const script = parseJsScript(`
+			const [{ closed }, posted] = await Promise.all([
+				github.closeIssue({ number: 7 }),
+				slack.post({ text: "hi" }),
+			]);
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.closeIssue", args: { number: 7 } },
+			{ id: "posted", call: "slack.post", args: { text: "hi" } },
+			{ id: "closed", let: "s1.closed" },
+		]);
+	});
+
+	it("minted ids never collide with names bound deep in a pattern", () => {
+		const script = parseJsScript(`
+			const { a: { s1 } } = await github.getThing({});
+		`);
+		expect(script.steps.map((s) => s.id)).toEqual(["s2", "s1"]);
+	});
+
+	it("runs end to end through the engine", async () => {
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => ({
+				items: [{ number: 1 }, { number: 2 }, { number: 3 }],
+				meta: { total: 3 },
+			}),
+		});
+		const engine = callscript({ tools: [listIssues] });
+		const result = await engine.run({
+			script: `
+				const { items, meta: { total, page = 1 }, missing = "none" } = await github.listIssues({});
+				const [head, ...tail] = items;
+				return { head, tail: tail.length, total, page, missing };
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") {
+			expect(result.output).toEqual({
+				head: { number: 1 },
+				tail: 2,
+				total: 3,
+				page: 1,
+				missing: "none",
+			});
+		}
+	});
+
+	it("computed keys, forbidden keys, and destructured detached calls stay rejected", () => {
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					const res = await github.listIssues({});
+					const { [key]: v } = res;
+				`),
+			)[0],
+		).toMatch(/computed key/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					const res = await github.listIssues({});
+					const { constructor } = res;
+				`),
+			)[0],
+		).toMatch(/constructor/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`const { id } = svc.export({});`, {
+					tools: ["svc.export"],
+				}),
+			)[0],
+		).toMatch(/detached call to one name/);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -909,6 +909,107 @@ describe("wrappers", () => {
 	});
 });
 
+describe("fan-out arrow bodies", () => {
+	// list.map(async item => { ... }) shares the for..of body grammar:
+	// locals, skip guards (a bare return), a trailing if, one call
+
+	it("a block body with locals, a skip guard, and a returned call", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			const closed = await Promise.all(issues.slice(0, 5).map(async i => {
+				const n = i.number;
+				if (!i.stale) return;
+				return await github.closeIssue({ number: n });
+			}));
+		`);
+		expect(script.steps[1]).toEqual({
+			id: "closed",
+			call: "github.closeIssue",
+			each: "(issues.slice(0, 5)).filter((i) => (!(!i.stale))).map((i) => ({ number: (i.number) }))",
+			max: 5,
+		});
+	});
+
+	it("a trailing if around the call; return without await; a bare awaited call", () => {
+		const guarded = parseJsScript(`
+			const results = await Promise.all(issues.map(async (i) => {
+				if (i.stale) {
+					const tag = \`#\${i.number}\`;
+					return slack.post({ text: tag });
+				}
+			}));
+		`);
+		expect((guarded.steps[0] as CallStep).each).toBe(
+			"(issues).filter((i) => (i.stale)).map((i) => ({ text: (`#${i.number}`) }))",
+		);
+		const bare = parseJsScript(`
+			await Promise.all(issues.map(async i => {
+				await github.closeIssue({ number: i.number });
+			}));
+		`);
+		expect((bare.steps[0] as CallStep).each).toBe(
+			"(issues).map((i) => ({ number: i.number }))",
+		);
+	});
+
+	it("runs end to end: only the guarded items dispatch", async () => {
+		const closed: number[] = [];
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => [
+				{ number: 1, stale: true },
+				{ number: 2, stale: false },
+				{ number: 3, stale: true },
+			],
+		});
+		const closeIssue = tool({
+			name: "github.closeIssue",
+			execute: (args: { number: number }) => {
+				closed.push(args.number);
+				return { closed: args.number };
+			},
+		});
+		const engine = callscript({ tools: [listIssues, closeIssue] });
+		const result = await engine.run({
+			script: `
+				const issues = await github.listIssues({});
+				const done = await Promise.all(issues.map(async i => {
+					if (!i.stale) return;
+					return await github.closeIssue({ number: i.number * 10 });
+				}));
+				return done.map(d => d.closed);
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") expect(result.output).toEqual([10, 30]);
+		expect(closed.sort()).toEqual([10, 30]);
+	});
+
+	it("a real arrow body stays rejected, naming the expression form", () => {
+		const message = /fan-out arrow's block is one awaited tool call/;
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					await Promise.all(issues.map(async i => {
+						const r = await github.closeIssue({ number: i.number });
+						await slack.post({ text: r.closed });
+					}));
+				`),
+			)[0],
+		).toMatch(message);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					await Promise.all(issues.map(async i => {
+						if (i.stale) return github.closeIssue({ number: i.number });
+						else return slack.post({ text: "kept" });
+					}));
+				`),
+			)[0],
+		).toMatch(message);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -812,6 +812,103 @@ describe("conditional assignment", () => {
 	});
 });
 
+describe("wrappers", () => {
+	// a model picturing a module wraps top-level await; the body is the
+	// script, so it compiles as the program
+
+	it("an async IIFE unwraps: body statements, return as output, comment as intent", () => {
+		for (const src of [
+			`
+				// close stale issues
+				(async () => {
+					const issues = await github.listIssues({ repo: "api" });
+					return { n: issues.length };
+				})();
+			`,
+			`
+				// close stale issues
+				await (async function () {
+					const issues = await github.listIssues({ repo: "api" });
+					return { n: issues.length };
+				})();
+			`,
+		]) {
+			const script = parseJsScript(src);
+			expect(script.intent).toBe("close stale issues");
+			expect(script.steps).toEqual([
+				{ id: "issues", call: "github.listIssues", args: { repo: "api" } },
+			]);
+			expect(script.output).toBe("{ n: issues.length }");
+		}
+	});
+
+	it("`async function main() { ... } main()` unwraps the same way", () => {
+		for (const tail of ["main();", "await main();"]) {
+			const script = parseJsScript(`
+				async function main() {
+					const issues = await github.listIssues({ repo: "api" });
+					if (issues.length === 0) return { n: 0 };
+					return { n: issues.length };
+				}
+				${tail}
+			`);
+			expect(script.steps.map((s) => s.id)).toEqual(["issues", "s1"]);
+			expect(script.output).toBe("{ n: issues.length }");
+		}
+	});
+
+	it("names inside the wrapper still reserve their ids", () => {
+		const script = parseJsScript(`
+			(async () => {
+				const s1 = await t.a({});
+				return { x: await t.b({}) };
+			})();
+		`);
+		expect(script.steps.map((s) => s.id)).toEqual(["s1", "s2"]);
+	});
+
+	it("runs end to end through the engine", async () => {
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => [{ number: 1 }, { number: 2 }],
+		});
+		const engine = callscript({ tools: [listIssues] });
+		const result = await engine.run({
+			script: `
+				async function main() {
+					const issues = await github.listIssues({});
+					return { n: issues.length };
+				}
+				main();
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") expect(result.output).toEqual({ n: 2 });
+	});
+
+	it("a .catch on the wrapper, or a main() not called plainly, is rejected with the reason", () => {
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					(async () => {
+						await github.listIssues({ repo: "api" });
+					})().catch(console.error);
+				`),
+			).join("\n"),
+		).toMatch(/drop the \.then\/\.catch/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					async function main() {
+						await github.listIssues({ repo: "api" });
+					}
+					main().catch(console.error);
+				`),
+			).join("\n"),
+		).toMatch(/call the wrapper plainly.*main\(\)/);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -711,6 +711,107 @@ describe("await hoisting", () => {
 	});
 });
 
+describe("conditional assignment", () => {
+	// `let x = a; if (cond) x = b;` is one derivation - the same plan as
+	// `const x = cond ? b : a`, without the retry over reassignment
+
+	it("`let x = a; if (c) x = b` becomes a conditional let", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			let label = "none";
+			if (issues.length > 0) label = "some";
+			return label;
+		`);
+		expect(script.steps[1]).toEqual({
+			id: "label",
+			let: '(issues.length > 0) ? ("some") : ("none")',
+		});
+		expect(script.output).toBe("label");
+	});
+
+	it("else branches, block bodies, and a dead initializer", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			let tone;
+			if (issues.length > 5) { tone = "busy"; } else { tone = "calm"; }
+			let first = null;
+			if (issues.length > 0) first = issues[0];
+			await slack.post({ text: \`\${tone}: \${first?.title ?? "-"}\` });
+		`);
+		expect(script.steps.slice(1, 3)).toEqual([
+			{ id: "tone", let: '(issues.length > 5) ? ("busy") : ("calm")' },
+			{ id: "first", let: "(issues.length > 0) ? (issues[0]) : (null)" },
+		]);
+		expect((script.steps[3] as CallStep).after).toBeUndefined();
+	});
+
+	it("inherits the enclosing guard", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			if (issues.length > 0) {
+				let n = 0;
+				if (issues[0].stale) n = 1;
+				await slack.post({ text: n });
+			}
+		`);
+		expect(script.steps[1]).toEqual({
+			id: "n",
+			let: "(issues[0].stale) ? (1) : (0)",
+			if: "issues.length > 0",
+		});
+	});
+
+	it("runs end to end through the engine", async () => {
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => [{ number: 1 }, { number: 2 }],
+		});
+		const engine = callscript({ tools: [listIssues] });
+		const result = await engine.run({
+			script: `
+				const issues = await github.listIssues({});
+				let label = "none";
+				if (issues.length > 1) label = "many";
+				let first;
+				if (issues.length > 0) first = issues[0].number; else first = -1;
+				return { label, first };
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") {
+			expect(result.output).toEqual({ label: "many", first: 1 });
+		}
+	});
+
+	it("stays narrow: else-if chains, awaits in a branch, and other work keep the reassignment message", () => {
+		const reassign = /single-assignment/;
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					let label = "none";
+					if (a) label = "x"; else if (b) label = "y";
+				`),
+			).join("\n"),
+		).toMatch(reassign);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					let r = null;
+					if (a) r = await t.fetch({});
+				`),
+			).join("\n"),
+		).toMatch(reassign);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					let n = 0;
+					if (a) { n = 1; await t.ping({}); }
+				`),
+			).join("\n"),
+		).toMatch(reassign);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -485,6 +485,121 @@ describe("destructuring", () => {
 	});
 });
 
+describe("for..of bodies", () => {
+	// a for..of IS Promise.all(list.map(...)), so its body may carry what
+	// a map arrow can express - and nothing more
+
+	it("an if guard around the call filters the list", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			for (const i of issues.slice(0, 10)) {
+				if (i.stale) await github.closeIssue({ number: i.number });
+			}
+		`);
+		expect(script.steps[1]).toEqual({
+			id: "s1",
+			call: "github.closeIssue",
+			each: "(issues.slice(0, 10)).filter((i) => (i.stale)).map((i) => ({ number: i.number }))",
+			max: 10,
+		});
+	});
+
+	it("`if (cond) continue` skips items; local consts inline into the call", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			for (const i of issues) {
+				const n = i.number;
+				const doubled = n * 2;
+				if (!i.stale) continue;
+				await github.closeIssue({ number: doubled, tag: \`#\${n}\` });
+			}
+		`);
+		expect((script.steps[1] as CallStep).each).toBe(
+			"(issues).filter((i) => (!(!i.stale))).map((i) => ({ number: ((i.number) * 2), tag: `#${(i.number)}` }))",
+		);
+	});
+
+	it("a guarded block may hold locals before its call; a bound call is fine", () => {
+		const script = parseJsScript(`
+			const issues = await github.listIssues({ repo: "api" });
+			for (const i of issues) {
+				if (i.stale) {
+					const label = \`#\${i.number}\`;
+					const r = await slack.post({ text: label });
+				}
+			}
+		`);
+		expect((script.steps[1] as CallStep).each).toBe(
+			"(issues).filter((i) => (i.stale)).map((i) => ({ text: (`#${i.number}`) }))",
+		);
+	});
+
+	it("runs end to end: only the guarded items dispatch, locals resolve", async () => {
+		const closed: number[] = [];
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: () => [
+				{ number: 1, stale: true },
+				{ number: 2, stale: false },
+				{ number: 3, stale: true },
+			],
+		});
+		const closeIssue = tool({
+			name: "github.closeIssue",
+			execute: (args: { number: number }) => {
+				closed.push(args.number);
+				return { closed: args.number };
+			},
+		});
+		const engine = callscript({ tools: [listIssues, closeIssue] });
+		const result = await engine.run({
+			script: `
+				const issues = await github.listIssues({});
+				for (const i of issues) {
+					const n = i.number;
+					if (!i.stale) continue;
+					await github.closeIssue({ number: n * 10 });
+				}
+			`,
+		});
+		expect(result.status).toBe("ok");
+		expect(closed.sort()).toEqual([10, 30]);
+	});
+
+	it("a real loop body stays rejected with the fan-out spelling", () => {
+		const message = /one awaited tool call.*Promise\.all\(list\.map/;
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					for (const i of issues) {
+						await github.closeIssue({ number: i.number });
+						await slack.post({ text: "closed" });
+					}
+				`),
+			)[0],
+		).toMatch(message);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					for (const i of issues) {
+						if (i.stale) await github.closeIssue({ number: i.number });
+						else await slack.post({ text: "kept" });
+					}
+				`),
+			)[0],
+		).toMatch(message);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					for (const i of issues) {
+						if (i.stale) return { first: i };
+					}
+				`),
+			)[0],
+		).toMatch(message);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -549,6 +549,28 @@ describe("teaching rejections", () => {
 		expect(msg).toContain("Promise.all");
 	});
 
+	it("forEach names the Promise.all fan-out", () => {
+		const issues = issuesOf(() =>
+			parseJsScript(`
+				const issues = await github.listIssues({ repo: "api" });
+				issues.forEach(i => github.closeIssue({ number: i.number }));
+			`),
+		);
+		expect(issues[0]).toMatch(
+			/forEach cannot fan out.*Promise\.all\(list\.map/,
+		);
+	});
+
+	it("console.log names the return-the-value fix", () => {
+		const issues = issuesOf(() =>
+			parseJsScript(`
+				const issues = await github.listIssues({ repo: "api" });
+				console.log(issues);
+			`),
+		);
+		expect(issues[0]).toMatch(/console\.log has nowhere to print.*return/);
+	});
+
 	it("reassignment names single-assignment", () => {
 		const issues = issuesOf(() => parseJsScript(`const a = 1;\na = 2;`));
 		expect(issues.join("\n")).toContain("single-assignment");

--- a/packages/callscript/src/js.test.ts
+++ b/packages/callscript/src/js.test.ts
@@ -600,6 +600,117 @@ describe("for..of bodies", () => {
 	});
 });
 
+describe("await hoisting", () => {
+	// an awaited call nested in an expression compiles into its own step
+	// first, and the expression reads the step - the plan the author gets
+	// by binding it, without the retry that used to demand the binding
+
+	it("`return { x: await tool() }` hoists the call and projects its id", () => {
+		const script = parseJsScript(`
+			return { issues: await github.listIssues({ repo: "api" }), n: 1 };
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.listIssues", args: { repo: "api" } },
+		]);
+		expect(script.output).toBe("{ issues: s1, n: 1 }");
+	});
+
+	it("an await inside a call's arguments hoists ahead of the call", () => {
+		const script = parseJsScript(`
+			const closed = await github.closeIssue({
+				number: (await github.getIssue({ n: 1 })).number,
+			});
+		`);
+		expect(script.steps).toEqual([
+			{ id: "s1", call: "github.getIssue", args: { n: 1 } },
+			{
+				id: "closed",
+				call: "github.closeIssue",
+				args: { number: "=(s1).number" },
+			},
+		]);
+	});
+
+	it("several awaits hoist in source order and chain like statements", () => {
+		const script = parseJsScript(`
+			const total = (await a.count({})) + (await b.count({}));
+			await slack.post({ text: total });
+		`);
+		const [first, second, total, post] = script.steps as [
+			CallStep,
+			CallStep,
+			LetStep,
+			CallStep,
+		];
+		expect(first).toEqual({ id: "s1", call: "a.count", args: {} });
+		expect(second).toEqual({
+			id: "s2",
+			call: "b.count",
+			args: {},
+			after: ["s1"],
+		});
+		expect(total).toEqual({ id: "total", let: "(s1) + (s2)" });
+		// the post reads total, which closes over both calls - no after edge
+		expect(post.after).toBeUndefined();
+	});
+
+	it("hoists inside guards and catch blocks, renames intact", () => {
+		const script = parseJsScript(`
+			try {
+				const closed = await github.closeIssue({ number: 1 });
+			} catch (e) {
+				const report = { text: e.message, sent: await slack.post({ text: e.message }) };
+			}
+		`);
+		const [, post, report] = script.steps as [CallStep, CallStep, LetStep];
+		expect(post).toMatchObject({
+			id: "s1",
+			call: "slack.post",
+			args: { text: "=$errors.closed.message" },
+			if: "$errors.closed",
+		});
+		expect(report).toEqual({
+			id: "report",
+			let: "{ text: $errors.closed.message, sent: s1 }",
+			if: "$errors.closed",
+		});
+	});
+
+	it("runs end to end through the engine", async () => {
+		const listIssues = tool({
+			name: "github.listIssues",
+			execute: (args: { repo: string }) => [
+				{ number: 1, repo: args.repo },
+				{ number: 2, repo: args.repo },
+			],
+		});
+		const engine = callscript({ tools: [listIssues] });
+		const result = await engine.run({
+			script: `
+				const n = (await github.listIssues({ repo: "api" })).length;
+				return { n, again: (await github.listIssues({ repo: "web" })).map(i => i.repo) };
+			`,
+		});
+		expect(result.status).toBe("ok");
+		if (result.status === "ok") {
+			expect(result.output).toEqual({ n: 2, again: ["web", "web"] });
+		}
+	});
+
+	it("a nested Promise.all and an await on a non-call stay rejected", () => {
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					return { closed: await Promise.all(xs.map(x => t.close({ x }))) };
+				`),
+			)[0],
+		).toMatch(/bind a fan-out first/);
+		expect(
+			issuesOf(() => parseJsScript(`return { v: (await job) + 1 };`))[0],
+		).toMatch(/await belongs directly on a tool call/);
+	});
+});
+
 describe("effect ordering", () => {
 	it("sequential awaited calls chain via after; data edges suppress it", () => {
 		const script = parseJsScript(`
@@ -717,11 +828,29 @@ describe("teaching rejections", () => {
 		}
 	});
 
-	it("await deep in an expression names the bind-first fix", () => {
-		const issues = issuesOf(() =>
-			parseJsScript(`const n = (await t.count({})) + 1;`),
-		);
-		expect(issues.join("\n")).toContain("bind it first");
+	it("await inside an arrow names the fan-out; inside a fan-out, the bind-first fix", () => {
+		expect(
+			issuesOf(() =>
+				parseJsScript(`const n = xs.map(async x => await t.count({ x }));`),
+			).join("\n"),
+		).toMatch(/await inside an arrow.*Promise\.all\(list\.map/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					const done = await Promise.all(xs.map(async x => t.close({ id: (await t.find({ x })).id })));
+				`),
+			).join("\n"),
+		).toMatch(/fan-out's arguments cannot await.*const x = await/);
+		expect(
+			issuesOf(() =>
+				parseJsScript(`
+					for (const x of xs) {
+						const found = { id: await t.find({ x }) };
+						await t.close({ id: found.id });
+					}
+				`),
+			).join("\n"),
+		).toMatch(/for\.\.of body|cannot await/);
 	});
 
 	it("issues carry source lines", () => {

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -17,8 +17,9 @@
  * error branch. The spellings models reach for most desugar too, each
  * into steps the author could have written by hand: destructuring
  * (`bindPattern`), awaits nested in expressions (`hoistAwaits`), loop
- * bodies with locals and guards (`compileForOf`), and the `let` +
- * `if` conditional value (`ifAssignDesugar`). What is stored, hashed,
+ * and fan-out-arrow bodies with locals and guards (`fanOutBody`), the
+ * `let` + `if` conditional value (`ifAssignDesugar`), and the async
+ * IIFE / main() wrappers (`unwrapProgram`). What is stored, hashed,
  * validated, and executed is ALWAYS the JSON plan, so nothing about
  * inertness, static checking, bounds, or resumability changes - this
  * file is a frontend, not a runtime.

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -1106,6 +1106,16 @@ export function parseJsScript(
 		}
 	};
 
+	/**
+	 * `for (const item of list) { ... }` fans out exactly like
+	 * `Promise.all(list.map(...))`, so the body may carry what a map arrow
+	 * can express: pure local consts (inlined into the call - `const n =
+	 * i.number` is a rename to `(i.number)`), `if (cond) continue` and
+	 * `if (cond) { ... }` guards around the call (a `.filter` on the
+	 * list), and exactly one awaited tool call, bound or bare. A second
+	 * call, an else branch, a return: that is a real loop body, and the
+	 * message names the fan-out spelling.
+	 */
 	const compileForOf = (node: acorn.ForOfStatement, ctx: Ctx) => {
 		if (node.await) {
 			issue(node, "for await is not needed - a plain for..of fans out");
@@ -1115,40 +1125,105 @@ export function parseJsScript(
 			return issue(left, "loop with one binding: for (const item of list)");
 		}
 		const param = left.declarations[0]!.id;
-		const body: acorn.Statement | undefined =
-			node.body.type === "BlockStatement"
-				? node.body.body.length === 1
-					? node.body.body[0]
-					: undefined
-				: node.body;
-		if (
-			body === undefined ||
-			body.type !== "ExpressionStatement" ||
-			body.expression.type !== "AwaitExpression" ||
-			body.expression.argument.type !== "CallExpression"
-		) {
-			return issue(
-				node,
-				"a for..of body must be exactly one awaited tool call - or spell the fan-out directly: await Promise.all(list.map(item => tool.name({ ... })))",
-			);
-		}
-		const innerCtx: Ctx = {
-			...ctx,
-			renames: shadowRenames(ctx.renames, [param]),
-		};
-		const step = compileCall(body.expression.argument, mint(), innerCtx);
-		if (step === undefined) return;
 		const listSrc = exprSrc(node.right, ctx);
 		if (listSrc === undefined) return;
 		const paramSrc = source.slice(param.start, param.end);
-		const argsNode = body.expression.argument.arguments[0];
+
+		const reject = (at: acorn.AnyNode): false => {
+			issue(
+				at,
+				"a for..of body is one awaited tool call, optionally behind local consts and an if guard - or spell the fan-out directly: await Promise.all(list.map(item => tool.name({ ... })))",
+			);
+			return false;
+		};
+
+		let renames = new Map(shadowRenames(ctx.renames, [param]) ?? []);
+		const filters: string[] = [];
+		let call: acorn.CallExpression | undefined;
+
+		const walk = (stmts: readonly acorn.Statement[]): boolean => {
+			for (const [index, stmt] of stmts.entries()) {
+				const last = index === stmts.length - 1;
+				if (stmt.type === "EmptyStatement") continue;
+				// Pure locals: inlined wherever the body reads them.
+				if (
+					stmt.type === "VariableDeclaration" &&
+					stmt.declarations.every(
+						(d) => d.init != null && d.init.type !== "AwaitExpression",
+					)
+				) {
+					for (const d of stmt.declarations) {
+						if (d.id.type !== "Identifier") return reject(d.id);
+						const text = exprSrc(d.init as acorn.AnyNode, { ...ctx, renames });
+						if (text === undefined) return false;
+						renames = new Map(renames);
+						renames.set(d.id.name, `(${text})`);
+					}
+					continue;
+				}
+				// Guards: `if (cond) continue;` skips the item, `if (cond) {
+				// ... }` ending the body keeps only the items that pass.
+				if (stmt.type === "IfStatement" && !stmt.alternate) {
+					const cond = exprSrc(stmt.test, { ...ctx, renames });
+					if (cond === undefined) return false;
+					const inner =
+						stmt.consequent.type === "BlockStatement"
+							? stmt.consequent.body
+							: [stmt.consequent];
+					if (inner.length === 1 && inner[0]!.type === "ContinueStatement") {
+						filters.push(`!(${cond})`);
+						continue;
+					}
+					if (!last) return reject(stmt);
+					filters.push(cond);
+					return walk(inner);
+				}
+				// The one awaited tool call ends the body.
+				const awaited: acorn.Expression | undefined =
+					stmt.type === "ExpressionStatement" &&
+					stmt.expression.type === "AwaitExpression"
+						? stmt.expression.argument
+						: stmt.type === "VariableDeclaration" &&
+								stmt.declarations.length === 1 &&
+								stmt.declarations[0]!.init?.type === "AwaitExpression"
+							? stmt.declarations[0]!.init.argument
+							: undefined;
+				if (
+					awaited === undefined ||
+					awaited.type !== "CallExpression" ||
+					!last
+				) {
+					return reject(stmt);
+				}
+				call = awaited;
+				return true;
+			}
+			return reject(node);
+		};
+		const body =
+			node.body.type === "BlockStatement" ? node.body.body : [node.body];
+		if (!walk(body) || call === undefined) return;
+
+		const innerCtx: Ctx = { ...ctx, renames };
+		const step = compileCall(call, mint(), innerCtx);
+		if (step === undefined) return;
+		const argsNode = call.arguments[0];
 		const argsSrc =
 			argsNode === undefined
 				? "{}"
 				: exprSrc(argsNode as acorn.AnyNode, innerCtx);
 		if (argsSrc === undefined) return;
 		delete step.args;
-		step.each = `(${listSrc}).map((${paramSrc}) => (${argsSrc}))`;
+		const list =
+			filters.length === 0
+				? `(${listSrc})`
+				: `(${listSrc}).filter((${paramSrc}) => ${filters.map((f) => `(${f})`).join(" && ")})`;
+		step.each = `${list}.map((${paramSrc}) => (${argsSrc}))`;
+		try {
+			parseExpr(step.each);
+		} catch (err) {
+			return issue(node, err instanceof ExprError ? err.message : String(err));
+		}
 		const bound = sliceBound(node.right);
 		if (bound !== undefined && step.max === undefined) step.max = bound;
 		pushCall(step, ctx);

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -234,6 +234,119 @@ export function parseJsScript(
 		return out;
 	};
 
+	/* ----------------------------- destructuring --------------------------- */
+
+	/** `src.key`, or `src["odd key"]` when the key is not an identifier. */
+	const memberSrc = (src: string, key: string): string =>
+		/^[A-Za-z_$][\w$]*$/.test(key)
+			? `${src}.${key}`
+			: `${src}[${JSON.stringify(key)}]`;
+
+	/** A pattern property's static key; undefined when computed. */
+	const propertyKey = (prop: acorn.AssignmentProperty): string | undefined => {
+		if (prop.computed) return undefined;
+		if (prop.key.type === "Identifier") return prop.key.name;
+		if (
+			prop.key.type === "Literal" &&
+			(typeof prop.key.value === "string" || typeof prop.key.value === "number")
+		) {
+			return String(prop.key.value);
+		}
+		return undefined;
+	};
+
+	/** A derivation the desugar generated: grammar-checked (a forbidden
+	 * key like `constructor` surfaces here, at the pattern's line). */
+	const pushLet = (
+		node: acorn.AnyNode,
+		id: string,
+		text: string,
+		ctx: Ctx,
+	): void => {
+		try {
+			parseExpr(text);
+		} catch (err) {
+			issue(node, err instanceof ExprError ? err.message : String(err));
+			return;
+		}
+		pushStep({ id, let: text }, ctx);
+	};
+
+	/**
+	 * DESTRUCTURING: `const { items, total = 0 } = x` and `const [head,
+	 * ...tail] = xs` desugar into one `let` step per bound name - a field
+	 * read off the source (`items = x.items`), which is exactly the
+	 * "bind to one name and read fields off it" spelling the plan already
+	 * has. `src` is always a cheap path off a step id, so a default may
+	 * repeat it (`x.total === undefined ? 0 : x.total`); a nested pattern
+	 * under a default reads from one minted id instead. Object rest keeps
+	 * every key the pattern did not name. Nothing here changes the plan
+	 * format: the steps are the ones the author could have written.
+	 */
+	const bindPattern = (pattern: acorn.Pattern, src: string, ctx: Ctx): void => {
+		switch (pattern.type) {
+			case "Identifier":
+				pushLet(pattern, pattern.name, src, ctx);
+				return;
+			case "AssignmentPattern": {
+				const fallback = exprSrc(pattern.right as acorn.AnyNode, ctx);
+				if (fallback === undefined) return;
+				const value = `${src} === undefined ? (${fallback}) : ${src}`;
+				if (pattern.left.type === "Identifier") {
+					pushLet(pattern, pattern.left.name, value, ctx);
+					return;
+				}
+				const id = mint();
+				pushLet(pattern, id, value, ctx);
+				bindPattern(pattern.left, id, ctx);
+				return;
+			}
+			case "ObjectPattern": {
+				const named: string[] = [];
+				for (const prop of pattern.properties) {
+					if (prop.type === "RestElement") {
+						const keep =
+							named.length === 0
+								? "true"
+								: named
+										.map((k) => `e[0] !== ${JSON.stringify(k)}`)
+										.join(" && ");
+						bindPattern(
+							prop.argument,
+							`Object.fromEntries(Object.entries(${src}).filter(e => ${keep}))`,
+							ctx,
+						);
+						continue;
+					}
+					const key = propertyKey(prop);
+					if (key === undefined) {
+						issue(
+							prop,
+							"destructure with plain keys - a computed key ([k]) is not a static binding",
+						);
+						continue;
+					}
+					named.push(key);
+					bindPattern(prop.value as acorn.Pattern, memberSrc(src, key), ctx);
+				}
+				return;
+			}
+			case "ArrayPattern": {
+				pattern.elements.forEach((el, index) => {
+					if (el === null) return; // a hole skips the element
+					if (el.type === "RestElement") {
+						bindPattern(el.argument, `${src}.slice(${index})`, ctx);
+						return;
+					}
+					bindPattern(el, `${src}[${index}]`, ctx);
+				});
+				return;
+			}
+			default:
+				issue(pattern, `unsupported binding pattern (${pattern.type})`);
+		}
+	};
+
 	/* ----------------------------- args & opts ----------------------------- */
 
 	/** A node that is pure JSON - embeddable as literal args. */
@@ -686,34 +799,25 @@ export function parseJsScript(
 						"one tool call per try - give each risky call its own try/catch",
 					);
 				}
-				const names: (string | undefined)[] =
-					binding === undefined
-						? inner.elements.map(() => undefined)
-						: binding.type === "ArrayPattern"
-							? binding.elements.map((el) =>
-									el === null
-										? undefined
-										: el.type === "Identifier"
-											? el.name
-											: undefined,
-								)
-							: [];
-				if (binding !== undefined && binding.type === "ArrayPattern") {
-					if (binding.elements.length !== inner.elements.length) {
-						return issue(
-							binding,
-							"destructure one name per call: const [a, b] = await Promise.all([...])",
-						);
-					}
-					if (
-						binding.elements.some(
-							(el) => el !== null && el.type !== "Identifier",
-						)
-					) {
-						return issue(binding, "plain names only in the destructuring");
-					}
+				// `const [a, b] = ...` names the calls; a nested pattern in an
+				// element (`[{ closed }, b]`) reads off its own minted call.
+				const elements =
+					binding?.type === "ArrayPattern" ? binding.elements : undefined;
+				if (
+					elements !== undefined &&
+					elements.length !== inner.elements.length
+				) {
+					return issue(
+						binding!,
+						"destructure one name per call: const [a, b] = await Promise.all([...])",
+					);
 				}
+				const names: (string | undefined)[] = inner.elements.map((_, i) => {
+					const el = elements?.[i];
+					return el && el.type === "Identifier" ? el.name : undefined;
+				});
 				const compiled: CallStep[] = [];
+				const byIndex: (CallStep | undefined)[] = [];
 				for (const [index, el] of inner.elements.entries()) {
 					if (!el || el.type === "SpreadElement") {
 						issue(inner, "Promise.all takes plain tool calls, no holes/spread");
@@ -729,6 +833,7 @@ export function parseJsScript(
 						continue;
 					}
 					const step = compileCall(callNode, names[index] ?? mint(), ctx);
+					byIndex[index] = step;
 					if (step !== undefined) compiled.push(step);
 				}
 				// All elements chain after the SAME prior frontier, then the
@@ -742,15 +847,33 @@ export function parseJsScript(
 					if (step.await !== false) nextFrontier.push(step.id);
 				}
 				frontier = nextFrontier.length > 0 ? nextFrontier : before;
-				// An Identifier binding gets the tuple as a value.
-				if (binding !== undefined && binding.type === "Identifier") {
-					pushStep(
-						{
-							id: binding.name,
-							let: `[${compiled.map((s) => s.id).join(", ")}]`,
-						},
-						ctx,
-					);
+				if (elements !== undefined) {
+					// Nested patterns in the tuple read off their own call step.
+					elements.forEach((el, index) => {
+						const step = byIndex[index];
+						if (el === null || el.type === "Identifier" || step === undefined) {
+							return;
+						}
+						if (el.type === "RestElement") {
+							issue(
+								el,
+								"destructure one name per call: const [a, b] = await Promise.all([...])",
+							);
+							return;
+						}
+						bindPattern(el, step.id, ctx);
+					});
+				} else if (binding !== undefined) {
+					// Any other binding gets the tuple as a value - a name
+					// directly, a pattern through a minted tuple step.
+					const tuple = `[${compiled.map((s) => s.id).join(", ")}]`;
+					if (binding.type === "Identifier") {
+						pushStep({ id: binding.name, let: tuple }, ctx);
+					} else {
+						const id = mint();
+						pushStep({ id, let: tuple }, ctx);
+						bindPattern(binding, id, ctx);
+					}
 				}
 				return undefined;
 			}
@@ -760,16 +883,23 @@ export function parseJsScript(
 			);
 		}
 
-		// Plain awaited tool call.
-		if (binding !== undefined && bindingName === undefined) {
-			return issue(
-				binding,
-				"destructuring a call result is not supported - bind it to one name and read fields off it",
-			);
-		}
+		// Plain awaited tool call. A destructured binding reads its fields
+		// off the call step: `const { items } = await t()` is the call under
+		// a minted id plus `items = <id>.items` - inside a try, only when
+		// the call succeeded (the catch branch owns the failure).
 		const step = compileCall(arg, bindingName ?? mint(), ctx);
 		if (step === undefined) return undefined;
-		return pushCall(step, ctx);
+		pushCall(step, ctx);
+		if (binding !== undefined && bindingName === undefined) {
+			bindPattern(
+				binding,
+				step.id,
+				where === "try"
+					? { ...ctx, cond: composeCond(ctx.cond, `!($errors.${step.id})`) }
+					: ctx,
+			);
+		}
+		return step;
 	};
 
 	/* ------------------------------ statements ----------------------------- */
@@ -784,17 +914,17 @@ export function parseJsScript(
 				compileAwaited(decl.init, decl.id, ctx, "statement");
 				continue;
 			}
-			if (decl.id.type !== "Identifier") {
-				issue(
-					decl.id,
-					"bind derived values to one name - destructure by deriving fields in later consts",
-				);
-				continue;
-			}
 			// Un-awaited call to a MOUNTED tool -> detached (fire-and-forget).
 			if (decl.init.type === "CallExpression") {
 				const name = dottedName(decl.init.callee);
 				if (name !== undefined && isMountedTool(name)) {
+					if (decl.id.type !== "Identifier") {
+						issue(
+							decl.id,
+							"bind a detached call to one name - const job = tool.name({ ... }); a later script joins it with await job",
+						);
+						continue;
+					}
 					const step = compileCall(decl.init, decl.id.name, ctx);
 					if (step !== undefined) {
 						step.await = false;
@@ -805,6 +935,17 @@ export function parseJsScript(
 			}
 			const text = exprSrc(decl.init, ctx);
 			if (text === undefined) continue;
+			if (decl.id.type !== "Identifier") {
+				// Destructuring a pure value: read the fields straight off a
+				// name/path source; anything else is derived once first.
+				let src = text;
+				if (dottedName(decl.init) === undefined) {
+					src = mint();
+					pushStep({ id: src, let: text }, ctx);
+				}
+				bindPattern(decl.id, src, ctx);
+				continue;
+			}
 			pushStep({ id: decl.id.name, let: text }, ctx);
 		}
 	};

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -1263,6 +1263,27 @@ export function parseJsScript(
 							}
 							continue;
 						}
+						// The two bare calls models write most: name the callscript
+						// spelling for each, not just the rule.
+						if (
+							expr.callee.type === "MemberExpression" &&
+							!expr.callee.computed &&
+							expr.callee.property.type === "Identifier" &&
+							expr.callee.property.name === "forEach"
+						) {
+							issue(
+								stmt,
+								"forEach cannot fan out - spell it: await Promise.all(list.map(item => tool.name({ ... })))",
+							);
+							continue;
+						}
+						if (name !== undefined && name.startsWith("console.")) {
+							issue(
+								stmt,
+								`${name} has nowhere to print - return the value instead (return { ... }); every step's output is already recorded`,
+							);
+							continue;
+						}
 						issue(
 							stmt,
 							name !== undefined

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -66,6 +66,10 @@ type Ctx = {
 	/** True only for the program's own statement list - where a trailing
 	 * `return` is the script's `output` rather than a guard step. */
 	topLevel: boolean;
+	/** Inside a fan-out's own arrow/body: a nested await cannot be hoisted
+	 * out (the step would read the per-element binding), so it is rejected
+	 * with the bind-first fix instead. */
+	noHoist?: boolean;
 };
 
 /**
@@ -199,18 +203,115 @@ export function parseJsScript(
 		return false;
 	};
 
-	/** Slice a node as an expression string: renames applied, grammar
-	 * checked (the checker's messages teach the pure-JS subset). */
-	const exprSrc = (node: acorn.AnyNode, ctx: Ctx): string | undefined => {
-		if (containsAwait(node)) {
+	/**
+	 * HOISTING: an awaited tool call nested in an expression - `return {
+	 * issues: await repo.list({}) }`, `tool({ id: (await other({})).id })`
+	 * - compiles into its own call step first, and the expression reads
+	 * the step where the await stood: exactly what the author gets by
+	 * binding it, so the plan is the same one. Statement order holds -
+	 * hoisted calls join the effect frontier like any awaited call, in
+	 * source order. Not hoistable: an await inside an arrow (a closure
+	 * runs per element - that is the fan-out's job) and any await inside
+	 * a fan-out's own arguments (`noHoist`). Returns the expression text
+	 * with every hoisted span replaced by its step id.
+	 */
+	const hoistAwaits = (node: acorn.AnyNode, ctx: Ctx): string | undefined => {
+		const awaits: acorn.AwaitExpression[] = [];
+		const collect = (n: unknown): void => {
+			if (n === null || typeof n !== "object") return;
+			const v = n as Record<string, unknown> & { type?: string };
+			if (
+				v.type === "ArrowFunctionExpression" ||
+				v.type === "FunctionExpression"
+			) {
+				return;
+			}
+			if (v.type === "AwaitExpression") {
+				// outermost only - an await inside this call's own arguments
+				// hoists when the call compiles its args
+				awaits.push(n as acorn.AwaitExpression);
+				return;
+			}
+			for (const [key, value] of Object.entries(v)) {
+				if (key === "loc") continue;
+				if (Array.isArray(value)) value.forEach(collect);
+				else if (
+					value !== null &&
+					typeof value === "object" &&
+					typeof (value as { type?: unknown }).type === "string"
+				) {
+					collect(value);
+				}
+			}
+		};
+		collect(node);
+		awaits.sort((a, b) => a.start - b.start);
+		if (ctx.noHoist) {
 			return issue(
 				node,
-				"await belongs on its own statement - bind it first (const x = await tool.name({ ... })), then derive from x",
+				"a fan-out's arguments cannot await - compute the value before the fan-out (const x = await tool.name({ ... })), then read x",
 			);
 		}
+		if (awaits.length === 0) {
+			return issue(
+				node,
+				"await inside an arrow cannot run - fan out instead: await Promise.all(list.map(item => tool.name({ ... })))",
+			);
+		}
+		const edits: { start: number; end: number; text: string }[] = [];
+		for (const a of awaits) {
+			const arg = a.argument;
+			const callee =
+				arg.type === "CallExpression" ? dottedName(arg.callee) : undefined;
+			if (callee === "Promise.all") {
+				return issue(
+					a,
+					"bind a fan-out first: const results = await Promise.all(...), then read results",
+				);
+			}
+			if (arg.type !== "CallExpression" || callee === undefined) {
+				return issue(
+					a,
+					"await belongs directly on a tool call - bind it first (const x = await tool.name({ ... })), then derive from x",
+				);
+			}
+			const step = compileCall(arg, mint(), ctx);
+			if (step === undefined) return undefined;
+			pushCall(step, ctx);
+			edits.push({ start: a.start, end: a.end, text: step.id });
+		}
 		let text = source.slice(node.start, node.end);
+		for (const e of edits.sort((x, y) => y.start - x.start)) {
+			text =
+				text.slice(0, e.start - node.start) +
+				e.text +
+				text.slice(e.end - node.start);
+		}
 		if (ctx.renames !== undefined && ctx.renames.size > 0) {
-			text = renameIdentifiers(text, node, node.start, ctx.renames);
+			// the spans are gone, so rename against a fresh parse of the text
+			const reparsed = acorn.parseExpressionAt(text, 0, {
+				ecmaVersion: 2022,
+				sourceType: "script",
+			});
+			text = renameIdentifiers(text, reparsed as acorn.AnyNode, 0, ctx.renames);
+		}
+		return text;
+	};
+
+	/** Slice a node as an expression string: nested awaits hoisted,
+	 * renames applied, grammar checked (the checker's messages teach the
+	 * pure-JS subset). */
+	const exprSrc = (node: acorn.AnyNode, ctx: Ctx): string | undefined => {
+		let text: string;
+		if (containsAwait(node)) {
+			const hoisted = hoistAwaits(node, ctx);
+			if (hoisted === undefined) return undefined;
+			text = hoisted;
+		} else {
+			text = source.slice(node.start, node.end);
+			if (ctx.renames !== undefined && ctx.renames.size > 0) {
+				text = renameIdentifiers(text, node, node.start, ctx.renames);
+			}
 		}
 		try {
 			parseExpr(text);
@@ -696,6 +797,7 @@ export function parseJsScript(
 		const innerCtx: Ctx = {
 			...ctx,
 			renames: shadowRenames(ctx.renames, cb.params),
+			noHoist: true,
 		};
 		const step = compileCall(body, id, innerCtx);
 		if (step === undefined) return undefined;
@@ -1154,7 +1256,11 @@ export function parseJsScript(
 				) {
 					for (const d of stmt.declarations) {
 						if (d.id.type !== "Identifier") return reject(d.id);
-						const text = exprSrc(d.init as acorn.AnyNode, { ...ctx, renames });
+						const text = exprSrc(d.init as acorn.AnyNode, {
+							...ctx,
+							renames,
+							noHoist: true,
+						});
 						if (text === undefined) return false;
 						renames = new Map(renames);
 						renames.set(d.id.name, `(${text})`);
@@ -1164,7 +1270,7 @@ export function parseJsScript(
 				// Guards: `if (cond) continue;` skips the item, `if (cond) {
 				// ... }` ending the body keeps only the items that pass.
 				if (stmt.type === "IfStatement" && !stmt.alternate) {
-					const cond = exprSrc(stmt.test, { ...ctx, renames });
+					const cond = exprSrc(stmt.test, { ...ctx, renames, noHoist: true });
 					if (cond === undefined) return false;
 					const inner =
 						stmt.consequent.type === "BlockStatement"
@@ -1204,7 +1310,7 @@ export function parseJsScript(
 			node.body.type === "BlockStatement" ? node.body.body : [node.body];
 		if (!walk(body) || call === undefined) return;
 
-		const innerCtx: Ctx = { ...ctx, renames };
+		const innerCtx: Ctx = { ...ctx, renames, noHoist: true };
 		const step = compileCall(call, mint(), innerCtx);
 		if (step === undefined) return;
 		const argsNode = call.arguments[0];

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -159,7 +159,80 @@ export function parseJsScript(
 			}
 		}
 	};
-	scanNames(program.body);
+	/**
+	 * WRAPPERS: `(async () => { ... })()` - awaited or not - and `async
+	 * function main() { ... }` followed by `main()` are how a model wraps
+	 * top-level await when it pictures a real module. The body IS the
+	 * script, so it compiles as the program: its trailing `return` is the
+	 * output, a leading comment the intent. A `.catch`/`.then` on the
+	 * wrapper is rejected with the reason - a failed call already fails
+	 * the run.
+	 */
+	type TopLevel = acorn.Statement | acorn.ModuleDeclaration;
+	const unwrapProgram = (stmts: readonly TopLevel[]): readonly TopLevel[] => {
+		/** The zero-argument call a statement makes, awaited or not. */
+		const callOf = (
+			stmt: TopLevel | undefined,
+		): acorn.CallExpression | undefined => {
+			if (stmt?.type !== "ExpressionStatement") return undefined;
+			let expr: acorn.Expression = stmt.expression;
+			if (expr.type === "AwaitExpression") expr = expr.argument;
+			return expr.type === "CallExpression" && expr.arguments.length === 0
+				? expr
+				: undefined;
+		};
+		const isWrapperFn = (
+			node: acorn.Expression | acorn.Super,
+		): node is acorn.ArrowFunctionExpression | acorn.FunctionExpression =>
+			(node.type === "ArrowFunctionExpression" ||
+				node.type === "FunctionExpression") &&
+			node.params.length === 0 &&
+			node.body.type === "BlockStatement";
+		if (stmts.length === 1) {
+			const call = callOf(stmts[0]);
+			if (call !== undefined && isWrapperFn(call.callee)) {
+				return (call.callee.body as acorn.BlockStatement).body;
+			}
+			// (async () => { ... })().catch(...) - the chained call is the tell
+			const stmt = stmts[0]!;
+			const expr =
+				stmt.type === "ExpressionStatement"
+					? stmt.expression.type === "AwaitExpression"
+						? stmt.expression.argument
+						: stmt.expression
+					: undefined;
+			if (
+				expr?.type === "CallExpression" &&
+				expr.callee.type === "MemberExpression" &&
+				expr.callee.object.type === "CallExpression" &&
+				isWrapperFn(expr.callee.object.callee)
+			) {
+				issue(
+					expr.callee.property,
+					"drop the .then/.catch on the wrapper - a failed call already fails the run, and the wrapper's return is the output",
+				);
+			}
+		}
+		if (
+			stmts.length === 2 &&
+			stmts[0]!.type === "FunctionDeclaration" &&
+			stmts[0]!.params.length === 0
+		) {
+			const fn = stmts[0] as acorn.FunctionDeclaration;
+			const name = fn.id?.name;
+			const call = callOf(stmts[1]);
+			if (call?.callee.type === "Identifier" && call.callee.name === name) {
+				return fn.body.body;
+			}
+			issue(
+				stmts[1]!,
+				`call the wrapper plainly as the last statement - ${name}() or await ${name}() - or drop it and write the statements at top level`,
+			);
+		}
+		return stmts;
+	};
+	const programBody = unwrapProgram(program.body);
+	scanNames(programBody);
 	let mintCounter = 0;
 	const mint = (): string => {
 		let id: string;
@@ -1607,7 +1680,7 @@ export function parseJsScript(
 
 	/* -------------------------------- program ------------------------------ */
 
-	const body = [...program.body];
+	const body = [...programBody];
 	// Intent: the leading comment's first line, or a leading string directive.
 	let intent: string | undefined;
 	const firstStart = body[0]?.start ?? source.length;

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -1336,6 +1336,71 @@ export function parseJsScript(
 	};
 
 	/**
+	 * The dominant model idiom for a conditional value:
+	 *
+	 *   let label = "none";                       // or  let label;
+	 *   if (issues.length > 0) label = "some";    // optionally: else label = "other";
+	 *
+	 * is one derivation, `label = cond ? "some" : "none"`, so desugar it
+	 * to that single-assignment let. Deliberately narrow: a non-const
+	 * binding with a pure (or missing) initializer, followed by an `if`
+	 * whose branches are exactly one assignment to that name each, and
+	 * no await anywhere in it - a call in a branch would hoist out
+	 * unconditionally, so it keeps the reassignment message instead.
+	 * Returns true when the pair was consumed.
+	 */
+	const ifAssignDesugar = (
+		decl: acorn.VariableDeclaration,
+		next: acorn.AnyNode | undefined,
+		ctx: Ctx,
+	): boolean => {
+		if (decl.kind === "const" || decl.declarations.length !== 1) return false;
+		const d = decl.declarations[0]!;
+		if (d.id.type !== "Identifier") return false;
+		const name = d.id.name;
+		if (next?.type !== "IfStatement" || containsAwait(next)) return false;
+		if (d.init != null && containsAwait(d.init)) return false;
+		/** The one `name = expr` a branch holds, else undefined. */
+		const assigned = (
+			branch: acorn.Statement,
+		): acorn.Expression | undefined => {
+			const stmt =
+				branch.type === "BlockStatement"
+					? branch.body.length === 1
+						? branch.body[0]
+						: undefined
+					: branch;
+			if (
+				stmt?.type !== "ExpressionStatement" ||
+				stmt.expression.type !== "AssignmentExpression" ||
+				stmt.expression.operator !== "=" ||
+				stmt.expression.left.type !== "Identifier" ||
+				stmt.expression.left.name !== name
+			) {
+				return undefined;
+			}
+			return stmt.expression.right;
+		};
+		const whenTrue = assigned(next.consequent);
+		if (whenTrue === undefined) return false;
+		const whenFalse =
+			next.alternate == null ? undefined : assigned(next.alternate);
+		if (next.alternate != null && whenFalse === undefined) return false;
+
+		const cond = exprSrc(next.test, ctx);
+		const a = exprSrc(whenTrue, ctx);
+		const b =
+			whenFalse !== undefined
+				? exprSrc(whenFalse, ctx)
+				: d.init != null
+					? exprSrc(d.init, ctx)
+					: "undefined";
+		if (cond === undefined || a === undefined || b === undefined) return true;
+		pushStep({ id: name, let: `(${cond}) ? (${a}) : (${b})` }, ctx);
+		return true;
+	};
+
+	/**
 	 * The dominant model idiom for a fallible call:
 	 *
 	 *   let r;            // or  let r = null / undefined
@@ -1414,6 +1479,10 @@ export function parseJsScript(
 					const desugared = tryAssignDesugar(stmt, stmts[index + 1]);
 					if (desugared !== undefined) {
 						compileTry(desugared, ctx);
+						index++;
+						continue;
+					}
+					if (ifAssignDesugar(stmt, stmts[index + 1], ctx)) {
 						index++;
 						continue;
 					}

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -844,8 +844,166 @@ export function parseJsScript(
 		return undefined;
 	};
 
+	/** What a fan-out body compiled to: the one call, the guards it sits
+	 * behind, and the local renames in force where it reads. */
+	type FanOutBody = {
+		call: acorn.CallExpression;
+		filters: string[];
+		renames: Map<string, string>;
+	};
+
+	/**
+	 * A fan-out BODY - the block of a `for..of`, or of a `list.map(async
+	 * item => { ... })` arrow - may carry what a map arrow can express:
+	 * pure locals (inlined into the call as renames - `const n =
+	 * i.number` becomes `(i.number)`), skip guards (`if (cond) continue;`
+	 * in a loop, `if (cond) return;` in an arrow), a trailing `if (cond)
+	 * { ... }` around the call, and exactly one awaited tool call: bound,
+	 * bare, or (in an arrow) returned. A second call, an else, or other
+	 * work is a real body, and `shape.message` names the fan-out spelling.
+	 */
+	const fanOutBody = (
+		stmts: readonly acorn.Statement[],
+		params: readonly acorn.Pattern[],
+		ctx: Ctx,
+		shape: { skip: "continue" | "return"; message: string; at: acorn.AnyNode },
+	): FanOutBody | undefined => {
+		const reject = (at: acorn.AnyNode): false => {
+			issue(at, shape.message);
+			return false;
+		};
+		const isSkip = (s: acorn.Statement): boolean =>
+			shape.skip === "continue"
+				? s.type === "ContinueStatement"
+				: s.type === "ReturnStatement" && s.argument == null;
+		/** The awaited call a statement makes, in the forms the body allows. */
+		const callIn = (s: acorn.Statement): acorn.Expression | undefined => {
+			if (s.type === "ExpressionStatement") {
+				return s.expression.type === "AwaitExpression"
+					? s.expression.argument
+					: undefined;
+			}
+			if (s.type === "VariableDeclaration") {
+				const init =
+					s.declarations.length === 1 ? s.declarations[0]!.init : null;
+				return init?.type === "AwaitExpression" ? init.argument : undefined;
+			}
+			if (
+				shape.skip === "return" &&
+				s.type === "ReturnStatement" &&
+				s.argument
+			) {
+				return s.argument.type === "AwaitExpression"
+					? s.argument.argument
+					: s.argument;
+			}
+			return undefined;
+		};
+		let renames = new Map(shadowRenames(ctx.renames, params) ?? []);
+		const filters: string[] = [];
+		let call: acorn.CallExpression | undefined;
+
+		const walk = (body: readonly acorn.Statement[]): boolean => {
+			for (const [index, stmt] of body.entries()) {
+				const last = index === body.length - 1;
+				if (stmt.type === "EmptyStatement") continue;
+				// Pure locals: inlined wherever the body reads them.
+				if (
+					stmt.type === "VariableDeclaration" &&
+					stmt.declarations.every(
+						(d) => d.init != null && d.init.type !== "AwaitExpression",
+					)
+				) {
+					for (const d of stmt.declarations) {
+						if (d.id.type !== "Identifier") return reject(d.id);
+						const text = exprSrc(d.init as acorn.AnyNode, {
+							...ctx,
+							renames,
+							noHoist: true,
+						});
+						if (text === undefined) return false;
+						renames = new Map(renames);
+						renames.set(d.id.name, `(${text})`);
+					}
+					continue;
+				}
+				// Guards: a skip drops the item, a trailing `if (cond) { ... }`
+				// keeps only the items that pass.
+				if (stmt.type === "IfStatement" && !stmt.alternate) {
+					const cond = exprSrc(stmt.test, { ...ctx, renames, noHoist: true });
+					if (cond === undefined) return false;
+					const inner =
+						stmt.consequent.type === "BlockStatement"
+							? stmt.consequent.body
+							: [stmt.consequent];
+					if (inner.length === 1 && isSkip(inner[0]!)) {
+						filters.push(`!(${cond})`);
+						continue;
+					}
+					if (!last) return reject(stmt);
+					filters.push(cond);
+					return walk(inner);
+				}
+				// The one awaited tool call ends the body.
+				const awaited = callIn(stmt);
+				if (
+					awaited === undefined ||
+					awaited.type !== "CallExpression" ||
+					!last
+				) {
+					return reject(stmt);
+				}
+				call = awaited;
+				return true;
+			}
+			return reject(shape.at);
+		};
+		if (!walk(stmts) || call === undefined) return undefined;
+		return { call, filters, renames };
+	};
+
+	/** The `each` step for a fan-out: the call compiled under the body's
+	 * renames, its args re-read per element, the guards as a `.filter`
+	 * on the list - which only shrinks it, so a slice bound still caps
+	 * the fan-out. */
+	const fanOutStep = (
+		body: FanOutBody,
+		id: string,
+		listNode: acorn.AnyNode,
+		paramSrc: string,
+		ctx: Ctx,
+		at: acorn.AnyNode,
+	): CallStep | undefined => {
+		const innerCtx: Ctx = { ...ctx, renames: body.renames, noHoist: true };
+		const step = compileCall(body.call, id, innerCtx);
+		if (step === undefined) return undefined;
+		const listSrc = exprSrc(listNode, ctx);
+		if (listSrc === undefined) return undefined;
+		const argsNode = body.call.arguments[0];
+		const argsSrc =
+			argsNode === undefined
+				? "{}"
+				: exprSrc(argsNode as acorn.AnyNode, innerCtx);
+		if (argsSrc === undefined) return undefined;
+		delete step.args;
+		const list =
+			body.filters.length === 0
+				? `(${listSrc})`
+				: `(${listSrc}).filter((${paramSrc}) => ${body.filters.map((f) => `(${f})`).join(" && ")})`;
+		step.each = `${list}.map((${paramSrc}) => (${argsSrc}))`;
+		try {
+			parseExpr(step.each);
+		} catch (err) {
+			return issue(at, err instanceof ExprError ? err.message : String(err));
+		}
+		const bound = sliceBound(listNode);
+		if (bound !== undefined && step.max === undefined) step.max = bound;
+		return step;
+	};
+
 	/** `await Promise.all(list.map(i => tool.name(args)))` -> an `each`
-	 * fan-out step. The body may be `async i => await tool(...)` too. */
+	 * fan-out step. The arrow may be `async i => await tool(...)`, or
+	 * carry a block body in the fan-out-body grammar. */
 	const compileFanOut = (
 		listNode: acorn.AnyNode,
 		cb: acorn.AnyNode,
@@ -858,29 +1016,30 @@ export function parseJsScript(
 				"fan out with an arrow: Promise.all(list.map(item => tool.name({ ... })))",
 			);
 		}
-		let body: acorn.AnyNode = cb.body as acorn.AnyNode;
-		if (body.type === "BlockStatement") {
-			return issue(
-				cb,
-				"the fan-out arrow must be a single call - list.map(item => tool.name({ ... })), no block body",
-			);
+		let body: FanOutBody | undefined;
+		if (cb.body.type === "BlockStatement") {
+			body = fanOutBody(cb.body.body, cb.params, ctx, {
+				skip: "return",
+				at: cb,
+				message:
+					"a fan-out arrow's block is one awaited tool call, optionally behind local consts and an if guard - or make it the expression: list.map(item => tool.name({ ... }))",
+			});
+			if (body === undefined) return undefined;
+		} else {
+			let expr: acorn.AnyNode = cb.body as acorn.AnyNode;
+			if (expr.type === "AwaitExpression") expr = expr.argument;
+			if (expr.type !== "CallExpression") {
+				return issue(
+					cb,
+					"the fan-out arrow must BE the tool call - compute the list first (const items = ...), then map each item to one call",
+				);
+			}
+			body = {
+				call: expr,
+				filters: [],
+				renames: new Map(shadowRenames(ctx.renames, cb.params) ?? []),
+			};
 		}
-		if (body.type === "AwaitExpression") body = body.argument;
-		if (body.type !== "CallExpression") {
-			return issue(
-				cb,
-				"the fan-out arrow must BE the tool call - compute the list first (const items = ...), then map each item to one call",
-			);
-		}
-		const innerCtx: Ctx = {
-			...ctx,
-			renames: shadowRenames(ctx.renames, cb.params),
-			noHoist: true,
-		};
-		const step = compileCall(body, id, innerCtx);
-		if (step === undefined) return undefined;
-		const listSrc = exprSrc(listNode, ctx);
-		if (listSrc === undefined) return undefined;
 		const paramsSrc =
 			cb.params.length === 0
 				? "_"
@@ -888,22 +1047,7 @@ export function parseJsScript(
 						cb.params[0]!.start,
 						cb.params[cb.params.length - 1]!.end,
 					);
-		const argsNode = body.arguments[0];
-		const argsSrc =
-			argsNode === undefined
-				? "{}"
-				: exprSrc(argsNode as acorn.AnyNode, innerCtx);
-		if (argsSrc === undefined) return undefined;
-		delete step.args;
-		step.each = `(${listSrc}).map((${paramsSrc}) => (${argsSrc}))`;
-		try {
-			parseExpr(step.each);
-		} catch (err) {
-			return issue(cb, err instanceof ExprError ? err.message : String(err));
-		}
-		const bound = sliceBound(listNode);
-		if (bound !== undefined && step.max === undefined) step.max = bound;
-		return step;
+		return fanOutStep(body, id, listNode, paramsSrc, ctx, cb);
 	};
 
 	/**
@@ -1305,112 +1449,27 @@ export function parseJsScript(
 			return issue(left, "loop with one binding: for (const item of list)");
 		}
 		const param = left.declarations[0]!.id;
-		const listSrc = exprSrc(node.right, ctx);
-		if (listSrc === undefined) return;
-		const paramSrc = source.slice(param.start, param.end);
-
-		const reject = (at: acorn.AnyNode): false => {
-			issue(
-				at,
-				"a for..of body is one awaited tool call, optionally behind local consts and an if guard - or spell the fan-out directly: await Promise.all(list.map(item => tool.name({ ... })))",
-			);
-			return false;
-		};
-
-		let renames = new Map(shadowRenames(ctx.renames, [param]) ?? []);
-		const filters: string[] = [];
-		let call: acorn.CallExpression | undefined;
-
-		const walk = (stmts: readonly acorn.Statement[]): boolean => {
-			for (const [index, stmt] of stmts.entries()) {
-				const last = index === stmts.length - 1;
-				if (stmt.type === "EmptyStatement") continue;
-				// Pure locals: inlined wherever the body reads them.
-				if (
-					stmt.type === "VariableDeclaration" &&
-					stmt.declarations.every(
-						(d) => d.init != null && d.init.type !== "AwaitExpression",
-					)
-				) {
-					for (const d of stmt.declarations) {
-						if (d.id.type !== "Identifier") return reject(d.id);
-						const text = exprSrc(d.init as acorn.AnyNode, {
-							...ctx,
-							renames,
-							noHoist: true,
-						});
-						if (text === undefined) return false;
-						renames = new Map(renames);
-						renames.set(d.id.name, `(${text})`);
-					}
-					continue;
-				}
-				// Guards: `if (cond) continue;` skips the item, `if (cond) {
-				// ... }` ending the body keeps only the items that pass.
-				if (stmt.type === "IfStatement" && !stmt.alternate) {
-					const cond = exprSrc(stmt.test, { ...ctx, renames, noHoist: true });
-					if (cond === undefined) return false;
-					const inner =
-						stmt.consequent.type === "BlockStatement"
-							? stmt.consequent.body
-							: [stmt.consequent];
-					if (inner.length === 1 && inner[0]!.type === "ContinueStatement") {
-						filters.push(`!(${cond})`);
-						continue;
-					}
-					if (!last) return reject(stmt);
-					filters.push(cond);
-					return walk(inner);
-				}
-				// The one awaited tool call ends the body.
-				const awaited: acorn.Expression | undefined =
-					stmt.type === "ExpressionStatement" &&
-					stmt.expression.type === "AwaitExpression"
-						? stmt.expression.argument
-						: stmt.type === "VariableDeclaration" &&
-								stmt.declarations.length === 1 &&
-								stmt.declarations[0]!.init?.type === "AwaitExpression"
-							? stmt.declarations[0]!.init.argument
-							: undefined;
-				if (
-					awaited === undefined ||
-					awaited.type !== "CallExpression" ||
-					!last
-				) {
-					return reject(stmt);
-				}
-				call = awaited;
-				return true;
-			}
-			return reject(node);
-		};
-		const body =
-			node.body.type === "BlockStatement" ? node.body.body : [node.body];
-		if (!walk(body) || call === undefined) return;
-
-		const innerCtx: Ctx = { ...ctx, renames, noHoist: true };
-		const step = compileCall(call, mint(), innerCtx);
-		if (step === undefined) return;
-		const argsNode = call.arguments[0];
-		const argsSrc =
-			argsNode === undefined
-				? "{}"
-				: exprSrc(argsNode as acorn.AnyNode, innerCtx);
-		if (argsSrc === undefined) return;
-		delete step.args;
-		const list =
-			filters.length === 0
-				? `(${listSrc})`
-				: `(${listSrc}).filter((${paramSrc}) => ${filters.map((f) => `(${f})`).join(" && ")})`;
-		step.each = `${list}.map((${paramSrc}) => (${argsSrc}))`;
-		try {
-			parseExpr(step.each);
-		} catch (err) {
-			return issue(node, err instanceof ExprError ? err.message : String(err));
-		}
-		const bound = sliceBound(node.right);
-		if (bound !== undefined && step.max === undefined) step.max = bound;
-		pushCall(step, ctx);
+		const body = fanOutBody(
+			node.body.type === "BlockStatement" ? node.body.body : [node.body],
+			[param],
+			ctx,
+			{
+				skip: "continue",
+				at: node,
+				message:
+					"a for..of body is one awaited tool call, optionally behind local consts and an if guard - or spell the fan-out directly: await Promise.all(list.map(item => tool.name({ ... })))",
+			},
+		);
+		if (body === undefined) return;
+		const step = fanOutStep(
+			body,
+			mint(),
+			node.right,
+			source.slice(param.start, param.end),
+			ctx,
+			node,
+		);
+		if (step !== undefined) pushCall(step, ctx);
 	};
 
 	/**

--- a/packages/callscript/src/js.ts
+++ b/packages/callscript/src/js.ts
@@ -14,9 +14,14 @@
  * and the parser desugars statement by statement - `const x = await
  * tool(...)` is a call step, `const x = expr` a let step, `if (c) return v`
  * a guard, `Promise.all(list.map(...))` a bounded fan-out, `try/catch` the
- * error branch. What is stored, hashed, validated, and executed is ALWAYS
- * the JSON plan, so nothing about inertness, static checking, bounds, or
- * resumability changes - this file is a frontend, not a runtime.
+ * error branch. The spellings models reach for most desugar too, each
+ * into steps the author could have written by hand: destructuring
+ * (`bindPattern`), awaits nested in expressions (`hoistAwaits`), loop
+ * bodies with locals and guards (`compileForOf`), and the `let` +
+ * `if` conditional value (`ifAssignDesugar`). What is stored, hashed,
+ * validated, and executed is ALWAYS the JSON plan, so nothing about
+ * inertness, static checking, bounds, or resumability changes - this
+ * file is a frontend, not a runtime.
  *
  * Anything outside the recognized grammar is rejected with the message
  * that names the callscript spelling, so the up-front instruction stays

--- a/packages/callscript/src/validate.test.ts
+++ b/packages/callscript/src/validate.test.ts
@@ -103,6 +103,31 @@ describe("validateScript", () => {
 		expect(issues.join("\n")).toMatch(/Unknown tool "listIsues"/);
 	});
 
+	it("an unknown tool suggests the nearest mounted name", () => {
+		const tools = ["github.listIssues", "github.closeIssue", "chat.post"];
+		const message = (call: string) =>
+			issuesOf(() =>
+				validateScript({ steps: [{ call, reason: "r" }] }, { tools }),
+			).join("\n");
+		// a typo in the name
+		expect(message("github.listIsues")).toMatch(
+			/did you mean "github\.listIssues"\?/,
+		);
+		// the right tool under the wrong namespace
+		expect(message("slack.post")).toMatch(/did you mean "chat\.post"\?/);
+		// nothing close: no guess, a wrong one costs a retry too
+		expect(message("deploy.rollback")).not.toMatch(/did you mean/);
+		// the host's hint still rides along
+		expect(
+			issuesOf(() =>
+				validateScript(
+					{ steps: [{ call: "github.listIsues", reason: "r" }] },
+					{ tools, unknownToolHint: "search for tools first" },
+				),
+			).join("\n"),
+		).toMatch(/did you mean "github\.listIssues"\? - search for tools first/);
+	});
+
 	it("known-tool names ending in '.*' are prefix patterns", () => {
 		const tools = ["shout", "github.*"];
 		expect(() =>

--- a/packages/callscript/src/validate.ts
+++ b/packages/callscript/src/validate.ts
@@ -381,9 +381,14 @@ export function validateScript(
 					(!step.call.includes("*") && knownTools.has(step.call)) ||
 					(!isInternalName(step.call) && wildcardOf!(step.call) !== undefined);
 				if (!known) {
+					const near = nearestToolName(step.call, knownTools);
+					const hints = [
+						near === undefined ? undefined : `did you mean "${near}"?`,
+						options.unknownToolHint,
+					].filter((h): h is string => h !== undefined);
 					issues.push({
 						path: `${at}.call`,
-						message: `Unknown tool "${step.call}"${options.unknownToolHint ? ` - ${options.unknownToolHint}` : ""}`,
+						message: `Unknown tool "${step.call}"${hints.length > 0 ? ` - ${hints.join(" - ")}` : ""}`,
 					});
 				}
 			}
@@ -523,4 +528,55 @@ export function validateScript(
 
 	if (issues.length > 0) throw new ScriptValidationError(issues);
 	return script;
+}
+
+/**
+ * The mounted name a typo most likely meant: within a small edit
+ * distance of the whole name (`listIsues` -> `listIssues`), or the same
+ * final segment under another namespace (`slack.post` -> `chat.post`).
+ * Undefined when nothing is close - a wrong guess costs a retry too.
+ */
+function nearestToolName(
+	name: string,
+	known: ReadonlySet<string>,
+): string | undefined {
+	const target = name.toLowerCase();
+	const budget = Math.max(2, Math.floor(target.length / 4));
+	const tail = target.slice(target.lastIndexOf(".") + 1);
+	let best: { name: string; score: number } | undefined;
+	for (const candidate of known) {
+		if (candidate.includes("*")) continue;
+		const c = candidate.toLowerCase();
+		let score = editDistance(target, c, budget);
+		if (score > budget) {
+			// A weaker match: the right tool in the wrong namespace.
+			const ctail = c.slice(c.lastIndexOf(".") + 1);
+			if (tail.length < 3 || tail !== ctail) continue;
+			score = budget + 1;
+		}
+		if (best === undefined || score < best.score) {
+			best = { name: candidate, score };
+		}
+	}
+	return best?.name;
+}
+
+/** Levenshtein distance, capped: answers `max + 1` as soon as the
+ * strings are further apart than `max`. */
+function editDistance(a: string, b: string, max: number): number {
+	if (Math.abs(a.length - b.length) > max) return max + 1;
+	let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+	for (let i = 1; i <= a.length; i++) {
+		const next = [i];
+		let rowMin = i;
+		for (let j = 1; j <= b.length; j++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			const d = Math.min(prev[j]! + 1, next[j - 1]! + 1, prev[j - 1]! + cost);
+			next.push(d);
+			if (d < rowMin) rowMin = d;
+		}
+		if (rowMin > max) return max + 1;
+		prev = next;
+	}
+	return prev[b.length]!;
 }


### PR DESCRIPTION
## What

The JS frontend now desugars the spellings models write most often into the let/call steps the author could have written by hand, instead of rejecting them and costing a repair round-trip. Nothing about the plan format, validation, limits, or reconciliation changes: every commit is frontend-only, and the plan that comes out is one the author could already have written.

One commit per feature, reviewable independently:

1. **Destructuring** – `const { items, total = 0 } = await repo.list({})` is the call plus one derivation per name (`items = s1.items`); `const [head, ...tail] = items` reads by index and `slice`. Renames, defaults, nesting, string keys, object rest, and nested patterns in a `Promise.all` tuple are covered. Inside `try/catch` the fields carry `if: !($errors.<id>)`. Computed keys, forbidden keys, and destructuring a detached call keep a pointed message. `patternNames` recurses so minted ids never collide with deep pattern names.
2. **`in` operator** – `"labels" in issue` evaluates as `Object.hasOwn`: plain data only, never a prototype chain, forbidden names still unreachable, non-object RHS is a type error as in JS.
3. **Pointed rejections** – `new Date` names `Date.parse`/`Date.now` (it used to get the `new Set` dedupe hint), `new RegExp` names `includes`/`startsWith`/`endsWith`, a bare `forEach` names the `Promise.all(list.map(...))` fan-out, `console.log` says to return the value, and an unknown tool suggests the nearest mounted name (capped edit distance, or the same tool under another namespace). No guess when nothing is close; `unknownToolHint` still rides along.
4. **for..of bodies** – a loop body may carry pure locals (inlined into the call as renames), `if (cond) continue`, and a trailing `if (cond) { ... }` around the one awaited call. Guards become a `.filter` on the list, so the `slice(0, N)` bound still caps the fan-out. A second call, an `else`, or a `return` stays rejected with the fan-out spelling.
5. **Nested awaits hoist** – `return { issues: await repo.list({}) }` and `close({ id: (await find({})).id })` compile each nested awaited call into its own step in source order, and the expression reads the step id. Hoisted calls join the effect frontier like any awaited call. Not hoistable, with the message: an await inside an arrow, inside a fan-out's own arguments or a loop body, a nested `Promise.all`, or an await on a non-call.
6. **`let x = a; if (cond) x = b`** – the conditional-value idiom compiles to the single derivation `x = cond ? b : a` (else branch, block bodies, dead initializer covered; inherits an enclosing guard). Else-if chains, other work in a branch, or an await anywhere in the pair keep the single-assignment message.
7. **Wider pure expression surface** – arrays: `at`, `findLast`, `findLastIndex`, `lastIndexOf`, `toSorted`, `toReversed`; strings: `at`, `substring`, `trimStart`, `trimEnd`, `charCodeAt`, `concat`; callable globals `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `encodeURIComponent`, `decodeURIComponent`, `encodeURI`, `decodeURI`, usable bare and as callbacks (`xs.map(Number)`, `xs.filter(Boolean)`); spread in call arguments (`Math.max(...xs)`); non-mutating `Object.assign`. Array mutators name the immutable spelling; `Math.random` says why it is out (a run must replay deterministically).
8. **Wrappers unwrap** – `(async () => { ... })()` (awaited or not, arrow or function expression) and `async function main() { ... } main()` compile as the program: the body's `return` is the output, a leading comment the intent, inner names still reserve their ids. A `.then`/`.catch` chained on the wrapper is rejected with the reason.
9. **Fan-out arrows with a block body** – `list.map(async i => { ... })` shares the for..of body grammar: locals, `if (cond) return;` as the skip guard, a trailing `if (cond) { ... }`, one awaited call (bound, bare, or returned). One shared walker (`fanOutBody`) and step builder (`fanOutStep`) serve both.
10. **Docs** (two commits) – README lists every new spelling and the pure natives expressions cover; the js.ts header points at the helper owning each desugar.

## Why

On a probe of 35 scripts written the way models actually write them, 16 were rejected by the frontend, and most of the rejections were these shapes – destructuring alone hit on every retry. Each one had an exact spelling in the plan already; the frontend just didn't do the translation.

## Tests

45 new cases across `js.test.ts`, `expr.test.ts`, and `validate.test.ts`: each form above, end-to-end runs through `engine.run`, and every rejection path. Suite: 318 passing, typecheck clean, biome clean. Probe of 35 model-written scripts: 28 accepted, up from 19 on main; the 7 left are deliberate and each names its fix.