### PR TITLE
fix: quote non-identifier keys in planToJs arg rendering

### DIFF
--- a/apps/web/lib/plan-to-js.test.ts
+++ b/apps/web/lib/plan-to-js.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { planToJs } from "./plan-to-js";
+
+/** Wrap planToJs output in a function so top-level `await` is legal, then
+ * confirm it parses. Parsing (not running) is the contract under test:
+ * planToJs renders a stored plan back to JS source for display and
+ * authoring, so its output must always be syntactically valid. */
+const isValidJs = (src: string): boolean => {
+	try {
+		new Function(`async function __probe__() {\n${src}\n}`);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const echo = (args: unknown) => ({
+	steps: [{ id: "a", call: "svc.echo", args, reason: "r" }],
+});
+
+describe("planToJs args rendering", () => {
+	it("keeps identifier keys bare", () => {
+		const out = planToJs(echo({ ok: 1, _x: 2, $y: 3 }) as never);
+		expect(out).toContain("{ ok: 1, _x: 2, $y: 3 }");
+		expect(isValidJs(out)).toBe(true);
+	});
+
+	it("keeps reserved words and unicode identifiers bare (legal property names)", () => {
+		const out = planToJs(echo({ class: 1, ünï: 2 }) as never);
+		expect(out).toContain("class: 1");
+		expect(out).toContain("ünï: 2");
+		expect(isValidJs(out)).toBe(true);
+	});
+
+	it("quotes non-identifier keys so the output stays valid JS", () => {
+		// Regression: args are z.record(z.string(), ...), so keys with spaces,
+		// dots, or hyphens are legal in a validated script. They previously
+		// rendered raw (`{ foo bar: 1 }`), which is a SyntaxError.
+		const out = planToJs(
+			echo({ "foo bar": 1, "a.b": 2, "a-b": 3, "123": 4 }) as never,
+		);
+		expect(out).toContain('"foo bar": 1');
+		expect(out).toContain('"a.b": 2');
+		expect(out).toContain('"a-b": 3');
+		expect(isValidJs(out)).toBe(true);
+	});
+
+	it("handles non-identifier keys nested inside objects and arrays", () => {
+		const out = planToJs(
+			echo({ outer: { "inner key": 1 }, list: [{ "k y": 2 }] }) as never,
+		);
+		expect(isValidJs(out)).toBe(true);
+		expect(out).toContain('"inner key": 1');
+		expect(out).toContain('"k y": 2');
+	});
+
+	it("round-trips the rendered args through eval to the original value", () => {
+		const out = planToJs(
+			echo({ ok: 1, "foo bar": 2, nested: { "a.b": 3 } }) as never,
+		);
+		// Pull the object literal back out and compare it to the input.
+		const match = /svc\.echo\(\{(.*)\}, \{ reason/.exec(out);
+		expect(match).not.toBeNull();
+		const evaled = new Function(`return ({ ${match![1]} });`)();
+		expect(evaled).toEqual({ ok: 1, "foo bar": 2, nested: { "a.b": 3 } });
+	});
+});

--- a/apps/web/lib/plan-to-js.ts
+++ b/apps/web/lib/plan-to-js.ts
@@ -1,5 +1,10 @@
 import type { CallStep, Script, Step } from "callscript";
 
+/** True when a key is safe to write bare as an object-literal key. Reserved
+ * words are fine as property names, so only identifier grammar is checked. */
+const isIdentifierKey = (key: string): boolean =>
+	/^[$_\p{ID_Start}](?:[$_\p{ID_Continue}]|\u200c|\u200d)*$/u.test(key);
+
 /** Render stored call args back to JS source: "=expr" strings become
  * bare expressions, "==lit" unescapes to the literal string. */
 function argsToJs(value: unknown): string {
@@ -13,7 +18,8 @@ function argsToJs(value: unknown): string {
 	}
 	if (value !== null && typeof value === "object") {
 		const entries = Object.entries(value).map(
-			([k, v]) => `${k}: ${argsToJs(v)}`,
+			([k, v]) =>
+				`${isIdentifierKey(k) ? k : JSON.stringify(k)}: ${argsToJs(v)}`,
 		);
 		return `{ ${entries.join(", ")} }`;
 	}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
 		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -23,6 +24,7 @@
 		"@types/react": "^19.1.0",
 		"@types/react-dom": "^19.1.0",
 		"tailwindcss": "^4.1.0",
-		"typescript": "^5.9.0"
+		"typescript": "^5.9.0",
+		"vitest": "^3.2.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   packages/callscript:
     dependencies:


### PR DESCRIPTION
## What

Fix `planToJs` in `apps/web/lib/plan-to-js.ts` so it quotes call-arg object keys that aren't valid identifier names. Previously a legal validated script carrying a key with a space, dot, or hyphen (permitted by the args schema's `z.record(z.string(), ...)`) rendered as syntactically invalid JS: `{ foo bar: 1 }` is a `SyntaxError`.

## Why

`planToJs` renders a stored plan back to its JS surface for display and authoring. Its output should be valid JS for every plan the engine can store. Identifier keys, reserved words, numeric-string keys, and unicode identifiers already render correctly and stay bare; only non-identifier keys were broken.

## Test coverage

`apps/web` had no test runner, so this renderer had zero regression coverage. This PR:

- adds a vitest seam to `apps/web` (vitest `^3.2.0`, matching `packages/callscript`, plus a `test` script) so the workspace `pnpm test` covers both packages
- adds `apps/web/lib/plan-to-js.test.ts` asserting identifier/reserved-word/unicode keys stay bare, non-identifier keys are quoted, the output always parses as valid JS, and rendered args round-trip through eval to the original value

Verified locally: the regression test fails against the pre-fix code (`SyntaxError: Unexpected identifier 'bar'`) and passes with the fix. Full `pnpm test`, `pnpm typecheck`, and `pnpm build` are green; `biome check` is clean over all tracked files.

Fixes #7
